### PR TITLE
Fix ui start command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,7 +126,7 @@ docker run --rm \
 pushd kythe/web/ui
 lein cljsbuild once prod # Build the necessary client-side code
 popd
-./campfire run //kythe/go/serving/xrefs/tools:xrefs_server --port 8080 --graphstore .kythe_graphstore
+./campfire run //kythe/go/serving/xrefs/tools:xrefs_server --listen localhost:8080 --graphstore .kythe_graphstore
 ----
 
 .Building the Kythe schema document


### PR DESCRIPTION
```
vagrant@jessie64:/vagrant$ ./campfire run //kythe/go/serving/xrefs/tools:xrefs_server --port 8080 --graphstore .kythe_graphstore
ninja: no work to do.
flag provided but not defined: -port
Usage of /vagrant/campfire-out/bin/kythe/go/serving/xrefs/tools/xrefs_server:
  -graphstore=<nil>: GraphStore to which to write the entry stream
  -indirect_names=false: For xrefs calls, indirect through name nodes to get a complete set of references
  -listen="localhost:8080": HTTP serving address
  -serving_path="kythe/web/ui/resources/public": Path to public serving directory
  -skip_preprocessing=false: Skip GraphStore preprocessing
  -tables="": Path to xrefs tables to serve
```