### PR TITLE
Add dependency on the compiler in //tools/modules:compiler_info

### DIFF
--- a/tools/modules/BUILD
+++ b/tools/modules/BUILD
@@ -9,7 +9,7 @@ genrule(
     cmd = ("echo \"BAZEL_CC=$$($(location :abspath) $(CC))\n" +
            "BAZEL_C_COMPILER=$(C_COMPILER)\" > $@"),
     tags = ["manual"],
-    tools = [":abspath"],
+    tools = [":abspath", "@local_config_cc//:toolchain"],
 )
 
 # This rule generates an empty .cc file if all modules are up to date.


### PR DESCRIPTION
This fixes the issue I was running into where `tools/modules/update.sh` wasn't working.
