### PR TITLE
Add linkopts=[-lpthread] for gflag and glog

### DIFF
--- a/third_party/googleflags.BUILD
+++ b/third_party/googleflags.BUILD
@@ -31,6 +31,9 @@ cc_library(
         "-DHAVE_RWLOCK",
         "-DGFLAGS_INTTYPES_FORMAT_C99",
     ],
+    linkopts = [
+        "-lpthread",
+    ],
     includes = [
         "include",
     ],

--- a/third_party/googlelog.BUILD
+++ b/third_party/googlelog.BUILD
@@ -39,6 +39,9 @@ cc_library(
         "-D_XOPEN_SOURCE",
         "-Ithird_party/googlelog/src",
     ],
+    linkopts = [
+        "-lpthread",
+    ],
     includes = [
         "include",
     ],


### PR DESCRIPTION
This matches the change in gflags' BUILD files: https://github.com/gflags/gflags/pull/189
It was required for Kythe to build on my desktop (Ubuntu 16.10)

Aside: gflags natively supports Bazel. Would it be reasonable for a follow-up PR to switch to using it directly via a `git_repository` rule vs. the custom BUILD file in this repo?