### PR TITLE
Teach kythe bazel to play nicely when included as an external bazel project

### DIFF
--- a/third_party/go/diff.BUILD
+++ b/third_party/go/diff.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/gapi.BUILD
+++ b/third_party/go/gapi.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/gcloud.BUILD
+++ b/third_party/go/gcloud.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/gogo_protobuf.BUILD
+++ b/third_party/go/gogo_protobuf.BUILD
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/grpc.BUILD
+++ b/third_party/go/grpc.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/levigo.BUILD
+++ b/third_party/go/levigo.BUILD
@@ -22,5 +22,5 @@ cgo_library(
             "doc.go",
         ],
     ),
-    cdeps = ["@//third_party/leveldb"],
+    cdeps = ["@io_kythe//third_party/leveldb"],
 )

--- a/third_party/go/oauth2.BUILD
+++ b/third_party/go/oauth2.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/pq.BUILD
+++ b/third_party/go/pq.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/protobuf.BUILD
+++ b/third_party/go/protobuf.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 licenses(["notice"])

--- a/third_party/go/shell.BUILD
+++ b/third_party/go/shell.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/snappy.BUILD
+++ b/third_party/go/snappy.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/stringset.BUILD
+++ b/third_party/go/stringset.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/subcommands.BUILD
+++ b/third_party/go/subcommands.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/uuid.BUILD
+++ b/third_party/go/uuid.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/x_net.BUILD
+++ b/third_party/go/x_net.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/x_text.BUILD
+++ b/third_party/go/x_text.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/go/x_tools.BUILD
+++ b/third_party/go/x_tools.BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["@//visibility:public"])
 
-load("@//third_party:go/build.bzl", "external_go_package")
+load("@io_kythe//third_party:go/build.bzl", "external_go_package")
 
 licenses(["notice"])
 

--- a/third_party/googlelog.BUILD
+++ b/third_party/googlelog.BUILD
@@ -46,7 +46,7 @@ cc_library(
         "include",
     ],
     deps = [
-        "@//third_party/googlelog:config_h",
+        "@io_kythe//third_party/googlelog:config_h",
         "@com_github_gflags_gflags//:gflags",
     ],
 )

--- a/tools/build_rules/autotools/autoconf.bzl
+++ b/tools/build_rules/autotools/autoconf.bzl
@@ -1,6 +1,6 @@
 """Skylark rules for generating files via an autotools ./configure script."""
 
-load("@//tools/cdexec:cdexec.bzl", "rootpath")
+load("//tools/cdexec:cdexec.bzl", "rootpath")
 
 def _fixtail(arg, prefixes):
   """If arg starts with any prefix, make tail be a root-relative path."""

--- a/tools/build_rules/config/local.bzl
+++ b/tools/build_rules/config/local.bzl
@@ -50,7 +50,7 @@ local_cc_library_configure = repository_rule(
         "default": attr.string(),
         "defines": attr.string_list(),
         "build_file_template": attr.label(
-            default = Label("@//tools/build_rules/config:BUILD.tpl"),
+            default = Label("@io_kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),

--- a/tools/build_rules/config/pkg_config.bzl
+++ b/tools/build_rules/config/pkg_config.bzl
@@ -158,7 +158,7 @@ pkg_config_package = repository_rule(
         "max_version": attr.string(),
         "exact_version": attr.string(),
         "build_file_template": attr.label(
-            default = Label("@//tools/build_rules/config:BUILD.tpl"),
+            default = Label("@io_kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),

--- a/tools/build_rules/config/system.bzl
+++ b/tools/build_rules/config/system.bzl
@@ -17,9 +17,9 @@ cc_system_package:
   repository, whose `:lib` target is then bound to '{name}'.
 """
 
-load("@//tools/build_rules/config:wrapped_ctx.bzl", "wrapctx")
-load("@//tools/build_rules/config:local.bzl", "setup_local_cc_library")
-load("@//tools/build_rules/config:pkg_config.bzl", "setup_pkg_config_package")
+load("//tools/build_rules/config:wrapped_ctx.bzl", "wrapctx")
+load("//tools/build_rules/config:local.bzl", "setup_local_cc_library")
+load("//tools/build_rules/config:pkg_config.bzl", "setup_pkg_config_package")
 
 def try_local_library(repo_ctx):
   if repo_ctx.attr.envvar and repo_ctx.attr.envvar in repo_ctx.os.environ:
@@ -58,7 +58,7 @@ cc_system_package_configure = repository_rule(
         "default": attr.string(),
         "defines": attr.string_list(),
         "build_file_template": attr.label(
-            default = Label("@//tools/build_rules/config:BUILD.tpl"),
+            default = Label("@io_kythe//tools/build_rules/config:BUILD.tpl"),
             single_file = True,
             allow_files = True,
         ),


### PR DESCRIPTION
We came across this testing out including `drake` as a bazel external (see RobotLocomotion/drake#6193).

If you make the following changes:
* Change @// to @io_kythe// to behave well when included as an external.
* Remove @// when in the context of a workspace-anchored Bazel file.

Then it seems like you can use `kythe` freely as a Bazel external (whereas we had to manually tweak some of the paths).
I've made a quick example here:
https://github.com/EricCousineau-TRI/kythe_super

I wasn't sure if there was a better way to do this. If there is, please do let me know if there is!

(NOTE: Will need some time to process the CLA. If anyone wants to recreate this minor change, I wouldn't mind :) )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/kythe/9)
<!-- Reviewable:end -->
