### PR TITLE
Split the cxx indexer lib target...

### DIFF
--- a/kythe/cxx/indexer/cxx/BUILD
+++ b/kythe/cxx/indexer/cxx/BUILD
@@ -1,28 +1,168 @@
 package(default_visibility = ["//kythe:default_visibility"])
 
 cc_library(
-    name = "lib",
+    name = "clang_utils",
+    srcs = [
+        "clang_utils.cc",
+    ],
+    hdrs = [
+        "clang_utils.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "google_flags_library_support",
+    srcs = [
+        "GoogleFlagsLibrarySupport.cc",
+    ],
+    hdrs = [
+        "GoogleFlagsLibrarySupport.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":indexer_library_support",
+        ":indexer_ast_hooks",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "graph_observer",
+    hdrs = [
+        "GraphObserver.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        "//kythe/cxx/common/indexing:lib",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "indexer_ast_hooks",
     srcs = [
         "IndexerASTHooks.cc",
-        "IndexerFrontendAction.cc",
-        "IndexerLibrarySupport.cc",
-        "IndexerPPCallbacks.cc",
-        "KytheGraphObserver.cc",
-        "ProtoLibrarySupport.cc",
-        "clang_utils.cc",
         "indexer_worklist.cc",
+    ],
+    hdrs = [
+        "IndexerASTHooks.h",
+        "indexer_worklist.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":marked_source",
+        ":graph_observer",
+        ":indexer_library_support",
+        "//kythe/cxx/common/indexing:lib",
+        "//kythe/cxx/common:lib",
+        "//kythe/cxx/common:supported_language",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "indexer_library_support",
+    hdrs = [
+        "IndexerLibrarySupport.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":graph_observer",
+        "//kythe/cxx/common/indexing:lib",
+        "//kythe/cxx/common:lib",
+        "//kythe/cxx/common:supported_language",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "indexer_pp_callbacks",
+    srcs = [
+        "IndexerPPCallbacks.cc",
+    ],
+    hdrs = [
+        "IndexerPPCallbacks.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":graph_observer",
+        ":indexer_ast_hooks",
+        "//kythe/cxx/common:lib",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "kythe_graph_observer",
+    srcs = [
+        "KytheGraphObserver.cc",
+    ],
+    hdrs = [
+        "KytheGraphObserver.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":graph_observer",
+        ":indexer_ast_hooks",
+        "//kythe/cxx/common/indexing:lib",
+        "//kythe/cxx/common:lib",
+        "//kythe/cxx/common:supported_language",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "marked_source",
+    srcs = [
         "marked_source.cc",
     ],
     hdrs = [
-        "GraphObserver.h",
-        "IndexerASTHooks.h",
-        "IndexerFrontendAction.h",
-        "IndexerLibrarySupport.h",
-        "IndexerPPCallbacks.h",
-        "KytheGraphObserver.h",
-        "ProtoLibrarySupport.h",
-        "clang_utils.h",
-        "indexer_worklist.h",
         "marked_source.h",
     ],
     copts = [
@@ -31,19 +171,71 @@ cc_library(
         "-Wno-implicit-fallthrough",
     ],
     deps = [
+        ":clang_utils",
+        ":graph_observer",
+        "//kythe/cxx/common/indexing:lib",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "proto_library_support",
+    srcs = [
+        "ProtoLibrarySupport.cc",
+    ],
+    hdrs = [
+        "ProtoLibrarySupport.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":indexer_ast_hooks",
+        ":indexer_library_support",
+        "//third_party/llvm",
+        "//third_party/llvm/src:clang_builtin_headers",
+        "//third_party/proto:protobuf",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+cc_library(
+    name = "lib",
+    srcs = [
+        "IndexerFrontendAction.cc",
+    ],
+    hdrs = [
+        "IndexerFrontendAction.h",
+    ],
+    copts = [
+        "-Wno-non-virtual-dtor",
+        "-Wno-unused-variable",
+        "-Wno-implicit-fallthrough",
+    ],
+    deps = [
+        ":clang_utils",
+        ":google_flags_library_support",
+        ":graph_observer",
+        ":indexer_pp_callbacks",
+        ":kythe_graph_observer",
+        ":marked_source",
+        ":proto_library_support",
         "//external:libmemcached",
+        "//kythe/cxx/common/indexing:lib",
         "//kythe/cxx/common:index_pack",
         "//kythe/cxx/common:json_proto",
         "//kythe/cxx/common:lib",
         "//kythe/cxx/common:supported_language",
-        "//kythe/cxx/common/indexing:lib",
         "//kythe/proto:analysis_proto_cc",
         "//kythe/proto:common_proto_cc",
         "//kythe/proto:cxx_proto_cc",
         "//kythe/proto:storage_proto_cc",
         "//third_party/llvm",
         "//third_party/llvm/src:clang_builtin_headers",
-        "//third_party/proto:protobuf",
         "@com_github_gflags_gflags//:gflags",
         "@com_github_google_glog//:glog",
     ],

--- a/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.cc
+++ b/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.cc
@@ -19,7 +19,7 @@
 #include "clang/AST/ASTContext.h"
 
 #include "IndexerASTHooks.h"
-#include "IndexerLibrarySupport.h"
+#include "GoogleFlagsLibrarySupport.h"
 
 namespace kythe {
 

--- a/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.h
+++ b/kythe/cxx/indexer/cxx/GoogleFlagsLibrarySupport.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file uses the Clang style conventions.
+
+#ifndef KYTHE_CXX_INDEXER_CXX_GOOGLE_FLAGS_LIBRARY_SUPPORT_H_
+#define KYTHE_CXX_INDEXER_CXX_GOOGLE_FLAGS_LIBRARY_SUPPORT_H_
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+
+#include "IndexerLibrarySupport.h"
+#include "GraphObserver.h"
+
+namespace kythe {
+
+/// \brief Snoops on variable declarations and references to see if they
+/// are flags.
+class GoogleFlagsLibrarySupport : public LibrarySupport {
+ public:
+  GoogleFlagsLibrarySupport() {}
+
+  /// \brief Emits a google/gflag node if `Decl` is a flag.
+  void InspectVariable(IndexerASTVisitor &V, GraphObserver::NodeId &DeclNodeId,
+                       GraphObserver::NodeId &DeclBodyNodeId,
+                       const clang::VarDecl *Decl,
+                       GraphObserver::Completeness Compl,
+                       const std::vector<Completion> &Compls) override;
+
+  /// \brief Checks whether this DeclRef refers to a flag. If so, it emits an
+  /// additional ref edge to the correspondng google/gflag node.
+  void InspectDeclRef(IndexerASTVisitor &V,
+                      clang::SourceLocation DeclRefLocation,
+                      const GraphObserver::Range &Ref,
+                      GraphObserver::NodeId &RefId,
+                      const clang::NamedDecl *TargetDecl) override;
+};
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_INDEXER_CXX_GOOGLE_FLAGS_LIBRARY_SUPPORT_H_

--- a/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
+++ b/kythe/cxx/indexer/cxx/IndexerFrontendAction.h
@@ -43,6 +43,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 
+#include "GoogleFlagsLibrarySupport.h"
 #include "GraphObserver.h"
 #include "IndexerASTHooks.h"
 #include "IndexerPPCallbacks.h"

--- a/kythe/cxx/indexer/cxx/IndexerLibrarySupport.h
+++ b/kythe/cxx/indexer/cxx/IndexerLibrarySupport.h
@@ -97,28 +97,6 @@ class LibrarySupport {
 /// \brief A collection of library support implementations.
 using LibrarySupports = std::vector<std::unique_ptr<LibrarySupport>>;
 
-/// \brief Snoops on variable declarations and references to see if they
-/// are flags.
-class GoogleFlagsLibrarySupport : public LibrarySupport {
- public:
-  GoogleFlagsLibrarySupport() {}
-
-  /// \brief Emits a google/gflag node if `Decl` is a flag.
-  void InspectVariable(IndexerASTVisitor &V, GraphObserver::NodeId &DeclNodeId,
-                       GraphObserver::NodeId &DeclBodyNodeId,
-                       const clang::VarDecl *Decl,
-                       GraphObserver::Completeness Compl,
-                       const std::vector<Completion> &Compls) override;
-
-  /// \brief Checks whether this DeclRef refers to a flag. If so, it emits an
-  /// additional ref edge to the correspondng google/gflag node.
-  void InspectDeclRef(IndexerASTVisitor &V,
-                      clang::SourceLocation DeclRefLocation,
-                      const GraphObserver::Range &Ref,
-                      GraphObserver::NodeId &RefId,
-                      const clang::NamedDecl *TargetDecl) override;
-};
-
 }  // namespace kythe
 
 #endif  // KYTHE_CXX_INDEXER_CXX_INDEXER_LIBRARY_SUPPORT_H_


### PR DESCRIPTION
... into several smaller targets to make dependencies clearer and improve recompilation times.