### PR TITLE
Add a missing header in index_packer.h

### DIFF
--- a/kythe/cxx/common/index_pack.h
+++ b/kythe/cxx/common/index_pack.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <functional>
 
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "kythe/proto/analysis.pb.h"


### PR DESCRIPTION
To fix a build error on Fedora 26 

In file included from kythe/cxx/common/index_pack.cc:17:
kythe/cxx/common/index_pack.h:51:12: error: no template named 'function' in namespace 'std'
      std::function<bool(google::protobuf::io::ZeroCopyOutputStream *stream,
