### PR TITLE
Update action_configs in clang_configure.bzl

### DIFF
--- a/tools/cpp/clang_configure.bzl
+++ b/tools/cpp/clang_configure.bzl
@@ -654,6 +654,7 @@ def _coverage_feature(darwin):
       flag_set {
         action: 'c++-link-interface-dynamic-library'
         action: 'c++-link-dynamic-library'
+        action: 'c++-link-nodeps-dynamic-library'
         action: 'c++-link-executable'
         """ + link_flags + """
       }


### PR DESCRIPTION
Make clang_configure.bzl ready for introduction of c++-link-nodeps-dynamic-library.
C++-link-nodeps-dynamic-library will be added in (google internal link) cl/186312427.