### PR TITLE
Add package cmdutil.

### DIFF
--- a/kythe/go/util/cmdutil/BUILD
+++ b/kythe/go/util/cmdutil/BUILD
@@ -1,0 +1,19 @@
+load("//tools:build_rules/shims.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+go_library(
+    name = "cmdutil",
+    srcs = ["cmdutil.go"],
+    deps = ["@com_github_google_subcommands//:go_default_library"],
+)
+
+go_test(
+    name = "cmdutil_test",
+    srcs = ["cmdutil_test.go"],
+    testonly = True,
+    deps = [
+        ":cmdutil",
+        "@com_github_google_subcommands//:go_default_library",
+    ],
+)

--- a/kythe/go/util/cmdutil/cmdutil.go
+++ b/kythe/go/util/cmdutil/cmdutil.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package cmdutil exports shared logic for implementing command-line
+// subcommands using the github.com/google/subcommands package.
+package cmdutil
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/google/subcommands"
+)
+
+// Info implements the methods of the subcommands.Command interface that handle
+// the command name and documentation. It also provides a noop default SetFlags
+// method and a default Execute method that prints its usage and exits.
+type Info struct {
+	name     string
+	synopsis string
+	usage    string
+}
+
+// NewInfo constructs an Info that reports the specified arguments for command
+// name, brief synopsis, and usage.
+func NewInfo(name, synopsis, usage string) Info {
+	if !strings.HasSuffix(usage, "\n") {
+		usage += "\n"
+	}
+	return Info{name: name, synopsis: synopsis, usage: usage}
+}
+
+// Name implements part of subcommands.Command.
+func (i Info) Name() string { return i.name }
+
+// Synopsis implements part of subcommands.Command.
+func (i Info) Synopsis() string { return i.synopsis }
+
+// Usage implements part of subcommands.Command.
+func (i Info) Usage() string { return i.usage + "\nOptions:\n" }
+
+// SetFlags implements part of subcommands.Command.
+func (i Info) SetFlags(*flag.FlagSet) {}
+
+// Execute implements part of subcommands.Command.
+// It prints the usage string to stdout and returns success.
+func (i Info) Execute(context.Context, *flag.FlagSet, ...interface{}) subcommands.ExitStatus {
+	fmt.Print(i.usage) // the undecorated usage string
+	return subcommands.ExitSuccess
+}
+
+// Fail logs an error message and returns subcommands.ExitFailure.
+func (i Info) Fail(msg string, args ...interface{}) subcommands.ExitStatus {
+	log.Output(1, fmt.Sprintf(msg, args...))
+	return subcommands.ExitFailure
+}

--- a/kythe/go/util/cmdutil/cmdutil_test.go
+++ b/kythe/go/util/cmdutil/cmdutil_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmdutil_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/google/subcommands"
+	"kythe.io/kythe/go/util/cmdutil"
+)
+
+func ExampleNewInfo() {
+	cmd := struct {
+		cmdutil.Info
+	}{
+		Info: cmdutil.NewInfo("example", "Demonstrate how to set up a subcommand",
+			`Show the user how to use the cmdutil.NewInfo function.`),
+	}
+
+	// Set up a flag set for demo purposes; most tools will use the default
+	// command line flags from the flag package.
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Parse([]string{"example", "foo"})
+
+	// Register a command with the dispatcher.
+	cmdr := subcommands.NewCommander(fs, "cmdutil_test")
+	cmdr.Register(cmd, "examples")
+
+	// Execute...
+	fmt.Println(cmdr.Execute(context.Background(), fs))
+	// Output:
+	// Show the user how to use the cmdutil.NewInfo function.
+	// 0
+}


### PR DESCRIPTION
This package contains shared logic for setting up command-line tools using the
subcommands package. The cmdutil.Info type handles reporting name, synopsis,
and usage information, and provides some default behaviour for other methods of
the required interface.