### PR TITLE
Look through ElaboratedTypes that elaborate typedefs when crawling the alias chain.

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -135,6 +135,13 @@ clang::QualType FollowAliasChain(const clang::TypedefNameDecl *TND) {
     Qs.addQualifiers(QT.getQualifiers());
     if (auto *TTD = dyn_cast<TypedefType>(QT.getTypePtr())) {
       TND = TTD->getDecl();
+    } else if (auto *ET = dyn_cast<ElaboratedType>(QT.getTypePtr())) {
+      if (auto* TDT = dyn_cast<TypedefType>(ET->getNamedType().getTypePtr())) {
+        TND = TDT->getDecl();
+        Qs.addQualifiers(ET->getNamedType().getQualifiers());
+      } else {
+        return QualType(QT.getTypePtr(), Qs.getFastQualifiers());
+      }
     } else {
       // We lose fidelity with getFastQualifiers.
       return QualType(QT.getTypePtr(), Qs.getFastQualifiers());

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -242,6 +242,13 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "alias_root_transitive",
+    srcs = ["basic/alias_root_transitive.cc"],
+    check_for_singletons = True,
+    tags = ["basic"],
+)
+
+cc_indexer_test(
     name = "alias_root_quals",
     srcs = ["basic/alias_root_quals.cc"],
     check_for_singletons = True,

--- a/kythe/cxx/indexer/cxx/testdata/basic/alias_root_transitive.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/alias_root_transitive.cc
@@ -1,0 +1,30 @@
+// aliases/root and aliases behave as we expect.
+
+template <typename Named>
+struct Aliaser {
+  //- @Type defines/binding AliaserType
+  using Type = Named;
+};
+
+//- @Root defines/binding RootAlias
+//- RootAlias aliases/root CharBuiltin
+//- CharBuiltin.node/kind tbuiltin
+using Root = char;
+
+//- @Type ref AliaserType
+//- @First defines/binding FirstAlias
+//- FirstAlias aliases AliaserType
+//- FirstAlias aliases/root CharBuiltin
+using First = typename Aliaser<Root>::Type;
+
+//- @Type ref AliaserType
+//- @Second defines/binding SecondAlias
+//- SecondAlias aliases AliaserType
+//- SecondAlias aliases/root CharBuiltin
+using Second = typename Aliaser<First>::Type;
+
+//- @Type ref AliaserType
+//- @Third defines/binding ThirdAlias
+//- ThirdAlias aliases AliaserType
+//- ThirdAlias aliases/root CharBuiltin
+using Third = typename Aliaser<Second>::Type;


### PR DESCRIPTION
Closes #26.