### PR TITLE
Add download/extract counts as well.

### DIFF
--- a/kythe/go/extractors/config/smoke/smoke_test.go
+++ b/kythe/go/extractors/config/smoke/smoke_test.go
@@ -113,7 +113,7 @@ func TestBasicExtraction(t *testing.T) {
 		extractionFiles: ef,
 	}
 
-	verifyRepoCoverage(t, te, 1.0)
+	verifyRepoCoverage(t, te, 2, 2, 1.0)
 }
 
 func TestMissingRepoFiles(t *testing.T) {
@@ -128,7 +128,7 @@ func TestMissingRepoFiles(t *testing.T) {
 		extractionFiles: ef,
 	}
 
-	verifyRepoCoverage(t, te, 0.5)
+	verifyRepoCoverage(t, te, 2, 1, 0.5)
 }
 
 func TestMultipleKindexFiles(t *testing.T) {
@@ -144,13 +144,14 @@ func TestMultipleKindexFiles(t *testing.T) {
 		separateKindex:  true,
 	}
 
-	verifyRepoCoverage(t, te, 1.0)
+	verifyRepoCoverage(t, te, 2, 2, 1.0)
 }
 
 // verifyRepoCoverage tests that a given testExtractor yields a specific
-// percentage coverage. The passed testExtractor should be set up with all of
-// the relevant input repo and extraction files.
-func verifyRepoCoverage(t *testing.T, te testExtractor, expectedCoverage float64) {
+// number of files downloaded, extracted, and percentage coverage. The passed
+// testExtractor should be set up with all of the relevant input repo and
+// extraction files.
+func verifyRepoCoverage(t *testing.T, te testExtractor, expectedDownloadCount, expectedExtractCount int, expectedCoverage float64) {
 	t.Helper()
 	h := harness{
 		extractor:   te,
@@ -167,6 +168,12 @@ func verifyRepoCoverage(t *testing.T, te testExtractor, expectedCoverage float64
 	}
 	if !r.Extracted {
 		t.Error("failed to extract")
+	}
+	if expectedDownloadCount != r.DownloadCount {
+		t.Errorf("expected %d downloaded files, got %d", expectedDownloadCount, r.DownloadCount)
+	}
+	if expectedExtractCount != r.ExtractCount {
+		t.Errorf("expected %d extracted files, got %d", expectedExtractCount, r.ExtractCount)
 	}
 	if !floatEquals(r.FileCoverage, expectedCoverage) {
 		t.Errorf("expected %.3f expectedCoverage, got %.3f", expectedCoverage, r.FileCoverage)

--- a/kythe/go/platform/tools/extraction/repotester.go
+++ b/kythe/go/platform/tools/extraction/repotester.go
@@ -66,8 +66,8 @@ func main() {
 	verifyFlags()
 
 	// Print some header
-	fmt.Printf("|%9s |%9s |%9s | %s\n", "download", "extract", "coverage", "repo")
-	fmt.Printf("|%9s |%9s |%9s |%s\n", " ----", " ----", " ----", " ----")
+	fmt.Printf("| %8s | %8s | %8s | %8s | %8s | %s\n", "download", "extracts", "dfilecnt", "efilecnt", "coverage", "repo")
+	fmt.Printf("| %8s | %8s | %8s | %8s | %8s | %s\n", "----", "----", "----", "----", "----", "----")
 
 	repos, err := getRepos()
 	if err != nil {
@@ -80,7 +80,7 @@ func main() {
 		if err != nil {
 			log.Printf("Failed to test repo: %s", err)
 		} else {
-			fmt.Printf("|%9t |%9t |     %3.0f%% | %s\n", res.Downloaded, res.Extracted, 100*res.FileCoverage, repo)
+			fmt.Printf("| %8t | %8t | %8d | %8d |     %3.0f%% | %s\n", res.Downloaded, res.Extracted, res.DownloadCount, res.ExtractCount, 100*res.FileCoverage, repo)
 		}
 	}
 }


### PR DESCRIPTION
Allows better eyeballing of e.g. empty repos for culling from test list,
or other obvious problems.