### PR TITLE
Cleanup: Write usage to flagset output instead of os.Stderr.

### DIFF
--- a/kythe/go/extractors/bazel/settings.go
+++ b/kythe/go/extractors/bazel/settings.go
@@ -75,7 +75,7 @@ func (s *Settings) SetFlags(f *flag.FlagSet, prefix string) func() {
 
 	// A default usage message the caller may use to populate flag.Usage.
 	return func() {
-		fmt.Fprintf(os.Stderr,
+		fmt.Fprintf(f.Output(),
 			`Usage: %s [options] -corpus C -language L -extra_action f.xa -output f.kindex
 
 Read an ExtraActionInput protobuf message from the designated -extra_action


### PR DESCRIPTION
When setting up flags for a Bazel extractor, write the usage message to the
writer owned by the flag set, instead of defaulting to stderr. The default is
stderr anyway, but this allows the caller to choose.