### PR TITLE
Prepare for forthcoming changes to Bazel toolchains/fragments

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("//:version.bzl", "check_version")
 
 # Check that the user has a version between our minimum supported version of
 # Bazel and our maximum supported version of Bazel.
-check_version("0.10.0", "0.13.0")
+check_version("0.13.0", "0.13.0")
 
 load("//tools/cpp:clang_configure.bzl", "clang_configure")
 

--- a/kythe/cxx/common/indexing/BUILD
+++ b/kythe/cxx/common/indexing/BUILD
@@ -39,6 +39,7 @@ cc_library(
         "//kythe/proto:common_cc_proto",
         "//kythe/proto:storage_cc_proto",
         "//third_party/llvm",
+        "@boringssl//:crypto",
         "@com_github_gflags_gflags//:gflags",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -184,7 +184,6 @@ cc_extract_kindex = rule(
     Each file in srcs will be extracted into a separate .kindex file, based on the name
     of the source.
     """,
-    fragments = ["cpp"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     outputs = _cc_extract_kindex_outs,
     implementation = _cc_extract_kindex_impl,

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -51,6 +51,8 @@ _INDEXER_FLAGS = {
 def _compiler_options(cpp):
   """Returns the combined list of compiler_options from the cpp fragment."""
   options = []
+  # The bazel toolchain provider is missing these attributes until 0.14.0,
+  # but we still want to use them when/if they are present.
   if hasattr(cpp, "compiler_options"):
     options += cpp.compiler_options([])
   if hasattr(cpp, "unfiltered_compiler_options"):

--- a/tools/build_rules/verifier_test/toolchain_utils.bzl
+++ b/tools/build_rules/verifier_test/toolchain_utils.bzl
@@ -14,20 +14,11 @@
 # limitations under the License.
 #
 
-def _find_cpp_toolchain(ctx):
-    if Label("@bazel_tools//tools/cpp:toolchain_type") in ctx.fragments.platform.enabled_toolchain_types:
-        return ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"]
-    else:
-        return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
-
 def find_cpp_toolchain(ctx):
     """Returns the appropriate C++ toolchain.
 
     If the c++ toolchain is in use, returns it.  Otherwise, returns a c++
     toolchain derived from legacy toolchain selection.
-
-    If neither of those have "compiler_options" falls back to
-    ctx.fragments.cpp.
 
     Args:
       ctx: The rule context for which to find a toolchain.
@@ -35,8 +26,7 @@ def find_cpp_toolchain(ctx):
     Returns:
       A CcToolchainProvider.
     """
-    cpp = _find_cpp_toolchain(ctx)
-    if hasattr(cpp, "compiler_options"):
-        return cpp
+    if Label("@bazel_tools//tools/cpp:toolchain_type") in ctx.fragments.platform.enabled_toolchain_types:
+        return ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"]
     else:
-        return ctx.fragments.cpp
+        return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]

--- a/tools/build_rules/verifier_test/toolchain_utils.bzl
+++ b/tools/build_rules/verifier_test/toolchain_utils.bzl
@@ -1,0 +1,42 @@
+#
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def _find_cpp_toolchain(ctx):
+    if Label("@bazel_tools//tools/cpp:toolchain_type") in ctx.fragments.platform.enabled_toolchain_types:
+        return ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"]
+    else:
+        return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+
+def find_cpp_toolchain(ctx):
+    """Returns the appropriate C++ toolchain.
+
+    If the c++ toolchain is in use, returns it.  Otherwise, returns a c++
+    toolchain derived from legacy toolchain selection.
+
+    If neither of those have "compiler_options" falls back to
+    ctx.fragments.cpp.
+
+    Args:
+      ctx: The rule context for which to find a toolchain.
+
+    Returns:
+      A CcToolchainProvider.
+    """
+    cpp = _find_cpp_toolchain(ctx)
+    if hasattr(cpp, "compiler_options"):
+        return cpp
+    else:
+        return ctx.fragments.cpp

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -1,5 +1,16 @@
-# Imported from https://github.com/bazelbuild/bazel/blob/master/tools/cpp/CROSSTOOL.tpl
-# with local modifications to integrate with LLVM.
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 major_version: "local"
 minor_version: ""
@@ -11,8 +22,18 @@ default_toolchain {
 }
 
 default_toolchain {
+  cpu: "local"
+  toolchain_identifier: "stub_armeabi-v7a"
+}
+
+default_toolchain {
   cpu: "armeabi-v7a"
   toolchain_identifier: "stub_armeabi-v7a"
+}
+
+default_toolchain {
+  cpu: "x64_windows"
+  toolchain_identifier: "msvc_x64"
 }
 
 default_toolchain {
@@ -28,6 +49,11 @@ default_toolchain {
 default_toolchain {
   cpu: "s390x"
   toolchain_identifier: "%{toolchain_name}"
+}
+
+default_toolchain {
+  cpu: "local"
+  toolchain_identifier: "ios_x86_64"
 }
 
 default_toolchain {
@@ -53,6 +79,7 @@ toolchain {
   target_cpu: "armeabi-v7a"
   target_system_name: "armeabi-v7a"
   toolchain_identifier: "stub_armeabi-v7a"
+
   tool_path { name: "ar" path: "/bin/false" }
   tool_path { name: "compat-ld" path: "/bin/false" }
   tool_path { name: "cpp" path: "/bin/false" }
@@ -83,6 +110,7 @@ toolchain {
   supports_interface_shared_objects: false
   supports_normalizing_ar: false
   supports_start_end_lib: false
+
   tool_path { name: "ar" path: "/bin/false" }
   tool_path { name: "compat-ld" path: "/bin/false" }
   tool_path { name: "cpp" path: "/bin/false" }
@@ -110,33 +138,71 @@ toolchain {
     mode: OPT
 %{opt_content}
   }
+  linking_mode_flags { mode: DYNAMIC }
 
 %{coverage}
+
+  feature {
+    name: 'fdo_optimize'
+    provides: 'profile'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      expand_if_all_available: 'fdo_profile_path'
+      flag_group {
+        flag: '-fprofile-use=%{fdo_profile_path}'
+        flag: '-fprofile-correction',
+      }
+    }
+  }
+}
+
+toolchain {
+  toolchain_identifier: "msys_x64_mingw"
+  abi_version: "local"
+  abi_libc_version: "local"
+  builtin_sysroot: ""
+  compiler: "mingw-gcc"
+  host_system_name: "local"
+  needsPic: false
+  target_libc: "mingw"
+  target_cpu: "x64_windows"
+  target_system_name: "local"
+
+%{msys_x64_mingw_content}
+
+  linking_mode_flags { mode: DYNAMIC }
 }
 
 toolchain {
   toolchain_identifier: "msvc_x64"
   host_system_name: "local"
   target_system_name: "local"
+
   abi_version: "local"
   abi_libc_version: "local"
   target_cpu: "x64_windows"
-  compiler: "cl"
-  target_libc: "msvcrt140"
+  compiler: "msvc-cl"
+  target_libc: "msvcrt"
   default_python_version: "python2.7"
+
 %{cxx_builtin_include_directory}
 
   tool_path {
     name: "ar"
-    path: "wrapper/bin/msvc_link.bat"
+    path: "%{msvc_lib_path}"
+  }
+  tool_path {
+    name: "ml"
+    path: "%{msvc_ml_path}"
   }
   tool_path {
     name: "cpp"
-    path: "wrapper/bin/msvc_cl.bat"
+    path: "%{msvc_cl_path}"
   }
   tool_path {
     name: "gcc"
-    path: "wrapper/bin/msvc_cl.bat"
+    path: "%{msvc_cl_path}"
   }
   tool_path {
     name: "gcov"
@@ -144,7 +210,7 @@ toolchain {
   }
   tool_path {
     name: "ld"
-    path: "wrapper/bin/msvc_link.bat"
+    path: "%{msvc_link_path}"
   }
   tool_path {
     name: "nm"
@@ -164,34 +230,25 @@ toolchain {
   }
   supports_gold_linker: false
   supports_start_end_lib: false
-  supports_interface_shared_objects: false
+  supports_interface_shared_objects: true
   supports_incremental_linker: false
   supports_normalizing_ar: true
   needsPic: false
 
-  compiler_flag: "-m64"
-  compiler_flag: "/D__inline__=__inline"
   # TODO(pcloudy): Review those flags below, they should be defined by cl.exe
-  compiler_flag: "/DOS_WINDOWS=OS_WINDOWS"
   compiler_flag: "/DCOMPILER_MSVC"
 
-  # Don't pollute with GDI macros in windows.h.
-  compiler_flag: "/DNOGDI"
   # Don't define min/max macros in windows.h.
   compiler_flag: "/DNOMINMAX"
-  compiler_flag: "/DPRAGMA_SUPPORTED"
+
   # Platform defines.
   compiler_flag: "/D_WIN32_WINNT=0x0600"
   # Turn off warning messages.
   compiler_flag: "/D_CRT_SECURE_NO_DEPRECATE"
   compiler_flag: "/D_CRT_SECURE_NO_WARNINGS"
   compiler_flag: "/D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS"
-  # Use math constants (M_PI, etc.) from the math library
-  compiler_flag: "/D_USE_MATH_DEFINES"
 
   # Useful options to have on for compilation.
-  # Suppress startup banner.
-  compiler_flag: "/nologo"
   # Increase the capacity of object files to 2^32 sections.
   compiler_flag: "/bigobj"
   # Allocate 500MB for precomputed headers.
@@ -202,9 +259,8 @@ toolchain {
   compiler_flag: "/Gy"
   # Use string pooling.
   compiler_flag: "/GF"
-  # Warning level 3 (could possibly go to 4 in the future).
-  compiler_flag: "/W3"
-  # Catch both asynchronous (structured) and synchronous (C++) exceptions.
+  # Catch C++ exceptions only and tell the compiler to assume that functions declared
+  # as extern "C" never throw a C++ exception.
   compiler_flag: "/EHsc"
 
   # Globally disabled warnings.
@@ -217,7 +273,196 @@ toolchain {
   # Don't warn about insecure functions (e.g. non _s functions).
   compiler_flag: "/wd4996"
 
-  linker_flag: "-m64"
+  linker_flag: "/MACHINE:X64"
+
+  feature {
+    name: "no_legacy_features"
+  }
+
+  # Suppress startup banner.
+  feature {
+    name: "nologo"
+    flag_set {
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-module-compile"
+      action: "c++-module-codegen"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      action: "c++-link-static-library"
+      flag_group {
+        flag: "/nologo"
+      }
+    }
+  }
+
+  feature {
+    name: 'has_configured_linker_path'
+  }
+
+  # This feature indicates strip is not supported, building stripped binary will just result a copy of orignial binary
+  feature {
+    name: 'no_stripping'
+  }
+
+  # This feature indicates this is a toolchain targeting Windows.
+  feature {
+    name: 'targets_windows'
+    implies: 'copy_dynamic_libraries_to_binary'
+    enabled: true
+  }
+
+  feature {
+    name: 'copy_dynamic_libraries_to_binary'
+  }
+
+  action_config {
+    config_name: 'assemble'
+    action_name: 'assemble'
+    tool {
+      tool_path: '%{msvc_ml_path}'
+    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
+    implies: 'nologo'
+    implies: 'msvc_env'
+    implies: 'sysroot'
+  }
+
+  action_config {
+    config_name: 'c-compile'
+    action_name: 'c-compile'
+    tool {
+      tool_path: '%{msvc_cl_path}'
+    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
+    implies: 'legacy_compile_flags'
+    implies: 'nologo'
+    implies: 'msvc_env'
+    implies: 'parse_showincludes'
+    implies: 'user_compile_flags'
+    implies: 'sysroot'
+    implies: 'unfiltered_compile_flags'
+  }
+
+  action_config {
+    config_name: 'c++-compile'
+    action_name: 'c++-compile'
+    tool {
+      tool_path: '%{msvc_cl_path}'
+    }
+    implies: 'compiler_input_flags'
+    implies: 'compiler_output_flags'
+    implies: 'legacy_compile_flags'
+    implies: 'nologo'
+    implies: 'msvc_env'
+    implies: 'parse_showincludes'
+    implies: 'user_compile_flags'
+    implies: 'sysroot'
+    implies: 'unfiltered_compile_flags'
+  }
+
+  action_config {
+    config_name: 'c++-link-executable'
+    action_name: 'c++-link-executable'
+    tool {
+      tool_path: '%{msvc_link_path}'
+    }
+    implies: 'nologo'
+    implies: 'linkstamps'
+    implies: 'output_execpath_flags'
+    implies: 'input_param_flags'
+    implies: 'user_link_flags'
+    implies: 'legacy_link_flags'
+    implies: 'linker_subsystem_flag'
+    implies: 'linker_param_file'
+    implies: 'msvc_env'
+    implies: 'use_linker'
+    implies: 'no_stripping'
+  }
+
+  action_config {
+    config_name: 'c++-link-dynamic-library'
+    action_name: 'c++-link-dynamic-library'
+    tool {
+      tool_path: '%{msvc_link_path}'
+    }
+    implies: 'nologo'
+    implies: 'shared_flag'
+    implies: 'linkstamps'
+    implies: 'output_execpath_flags'
+    implies: 'input_param_flags'
+    implies: 'user_link_flags'
+    implies: 'legacy_link_flags'
+    implies: 'linker_subsystem_flag'
+    implies: 'linker_param_file'
+    implies: 'msvc_env'
+    implies: 'use_linker'
+    implies: 'no_stripping'
+    implies: 'has_configured_linker_path'
+    implies: 'def_file'
+  }
+
+  action_config {
+      config_name: 'c++-link-nodeps-dynamic-library'
+      action_name: 'c++-link-nodeps-dynamic-library'
+      tool {
+        tool_path: '%{msvc_link_path}'
+      }
+      implies: 'nologo'
+      implies: 'shared_flag'
+      implies: 'linkstamps'
+      implies: 'output_execpath_flags'
+      implies: 'input_param_flags'
+      implies: 'user_link_flags'
+      implies: 'legacy_link_flags'
+      implies: 'linker_subsystem_flag'
+      implies: 'linker_param_file'
+      implies: 'msvc_env'
+      implies: 'use_linker'
+      implies: 'no_stripping'
+      implies: 'has_configured_linker_path'
+      implies: 'def_file'
+    }
+
+  action_config {
+    config_name: 'c++-link-static-library'
+    action_name: 'c++-link-static-library'
+    tool {
+      tool_path: '%{msvc_lib_path}'
+    }
+    implies: 'nologo'
+    implies: 'archiver_flags'
+    implies: 'input_param_flags'
+    implies: 'linker_param_file'
+    implies: 'msvc_env'
+  }
+
+  # TODO(b/65151735): Remove legacy_compile_flags feature when legacy fields are
+  # not used in this crosstool
+  feature {
+    name: 'legacy_compile_flags'
+    flag_set {
+      expand_if_all_available: 'legacy_compile_flags'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        iterate_over: 'legacy_compile_flags'
+        flag: '%{legacy_compile_flags}'
+      }
+    }
+  }
 
   feature {
     name: "msvc_env"
@@ -225,16 +470,15 @@ toolchain {
       action: "c-compile"
       action: "c++-compile"
       action: "c++-module-compile"
+      action: "c++-module-codegen"
       action: "c++-header-parsing"
       action: "c++-header-preprocessing"
       action: "assemble"
       action: "preprocess-assemble"
       action: "c++-link-executable"
       action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
       action: "c++-link-static-library"
-      action: "c++-link-alwayslink-static-library"
-      action: "c++-link-pic-static-library"
-      action: "c++-link-alwayslink-pic-static-library"
       env_entry {
         key: "PATH"
         value: "%{msvc_env_path}"
@@ -251,12 +495,30 @@ toolchain {
         key: "TMP"
         value: "%{msvc_env_tmp}"
       }
+      env_entry {
+        key: "TEMP"
+        value: "%{msvc_env_tmp}"
+      }
+    }
+  }
+
+  feature {
+    name: "use_linker"
+    env_set {
+      action: "c++-link-executable"
+      action: "c++-link-dynamic-library"
+      action: "c++-link-nodeps-dynamic-library"
+      env_entry {
+        key: "USE_LINKER"
+        value: "1"
+      }
     }
   }
 
   feature {
     name: 'include_paths'
     flag_set {
+      action: "assemble"
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
@@ -264,288 +526,139 @@ toolchain {
       action: 'c++-header-preprocessing'
       action: 'c++-module-compile'
       flag_group {
+        iterate_over: 'quote_include_paths'
         flag: '/I%{quote_include_paths}'
       }
       flag_group {
+        iterate_over: 'include_paths'
         flag: '/I%{include_paths}'
       }
       flag_group {
+        iterate_over: 'system_include_paths'
         flag: '/I%{system_include_paths}'
       }
     }
   }
 
   feature {
-    name: 'dependency_file'
+    name: "preprocessor_defines"
     flag_set {
-      action: 'assemble'
+      action: "assemble"
+      action: "preprocess-assemble"
+      action: "c-compile"
+      action: "c++-compile"
+      action: "c++-header-parsing"
+      action: "c++-header-preprocessing"
+      action: "c++-module-compile"
+      flag_group {
+        flag: "/D%{preprocessor_defines}"
+        iterate_over: "preprocessor_defines"
+      }
+    }
+  }
+
+  # Tell Bazel to parse the output of /showIncludes
+  feature {
+    name: 'parse_showincludes'
+    flag_set {
       action: 'preprocess-assemble'
       action: 'c-compile'
       action: 'c++-compile'
       action: 'c++-module-compile'
       action: 'c++-header-preprocessing'
       action: 'c++-header-parsing'
-      expand_if_all_available: 'dependency_file'
       flag_group {
-        flag: '/DEPENDENCY_FILE'
-        flag: '%{dependency_file}'
+        flag: "/showIncludes"
       }
     }
   }
 
-  # Stop passing -frandom-seed option
+
   feature {
-    name: 'random_seed'
-  }
-
-  # This feature is just for enabling flag_set in action_config for -c and -o options during the transitional period
-  feature {
-    name: 'compile_action_flags_in_flag_set'
-  }
-
-  action_config {
-    config_name: 'c-compile'
-    action_name: 'c-compile'
-    tool {
-      tool_path: 'wrapper/bin/msvc_cl.bat'
+    name: 'generate_pdb_file'
+    requires: {
+      feature: 'dbg'
     }
-    flag_set {
-      flag_group {
-        flag: '/c'
-        flag: '%{source_file}'
-      }
+    requires: {
+      feature: 'fastbuild'
     }
-    flag_set {
-      expand_if_all_available: 'output_object_file'
-      flag_group {
-        flag: '/Fo%{output_object_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_assembly_file'
-      flag_group {
-        flag: '/Fa%{output_assembly_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_preprocess_file'
-      flag_group {
-        flag: '/P'
-        flag: '/Fi%{output_preprocess_file}'
-      }
-    }
-    implies: 'msvc_env'
-  }
-
-  action_config {
-    config_name: 'c++-compile'
-    action_name: 'c++-compile'
-    tool {
-      tool_path: 'wrapper/bin/msvc_cl.bat'
-    }
-    flag_set {
-      flag_group {
-        flag: '/c'
-        flag: '%{source_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_object_file'
-      flag_group {
-        flag: '/Fo%{output_object_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_assembly_file'
-      flag_group {
-        flag: '/Fa%{output_assembly_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'output_preprocess_file'
-      flag_group {
-        flag: '/P'
-        flag: '/Fi%{output_preprocess_file}'
-      }
-    }
-    implies: 'msvc_env'
-  }
-
-  action_config {
-     config_name: 'c++-link-executable'
-     action_name: 'c++-link-executable'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'strip_debug_symbols'
-     implies: 'linkstamps'
-     implies: 'output_execpath_flags'
-     implies: 'input_param_flags'
-     implies: 'legacy_link_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  action_config {
-     config_name: 'c++-link-dynamic-library'
-     action_name: 'c++-link-dynamic-library'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'strip_debug_symbols'
-     implies: 'shared_flag'
-     implies: 'linkstamps'
-     implies: 'output_execpath_flags'
-     implies: 'input_param_flags'
-     implies: 'has_configured_linker_path'
-     implies: 'legacy_link_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  action_config {
-     config_name: 'c++-link-static-library'
-     action_name: 'c++-link-static-library'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'input_param_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  action_config {
-     config_name: 'c++-link-alwayslink-static-library'
-     action_name: 'c++-link-alwayslink-static-library'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'input_param_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  # TODO(pcloudy): The following action_config is listed in MANDATORY_LINK_TARGET_TYPES.
-  # But do we really need them on Windows?
-  action_config {
-     config_name: 'c++-link-pic-static-library'
-     action_name: 'c++-link-pic-static-library'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'input_param_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  action_config {
-     config_name: 'c++-link-alwayslink-pic-static-library'
-     action_name: 'c++-link-alwayslink-pic-static-library'
-     tool {
-         tool_path: 'wrapper/bin/msvc_link.bat'
-     }
-     implies: 'input_param_flags'
-     implies: 'linker_param_file'
-     implies: 'msvc_env'
-  }
-
-  action_config {
-    config_name: 'c++-link-interface-dynamic-library'
-    action_name: 'c++-link-interface-dynamic-library'
-    tool {
-      tool_path: 'wrapper/bin/msvc_link.bat'
-    }
-    implies: 'strip_debug_symbols'
-    implies: 'linker_param_file'
-    implies: 'msvc_env'
   }
 
   feature {
-    name: 'has_configured_linker_path'
+    name: 'shared_flag'
+    flag_set {
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: '/DLL'
+      }
+    }
   }
 
   feature {
-    name: 'strip_debug_symbols'
+    name: 'linkstamps'
     flag_set {
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
-      action: 'c++-link-interface-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      expand_if_all_available: 'linkstamp_paths'
       flag_group {
-        expand_if_all_available: 'strip_debug_symbols'
-        flag: '-Wl,-S'
+        iterate_over: 'linkstamp_paths'
+        flag: '%{linkstamp_paths}'
       }
     }
   }
 
   feature {
-     name: 'shared_flag'
-     flag_set {
-         action: 'c++-link-dynamic-library'
-         flag_group {
-             flag: '/DLL'
-         }
-     }
+    name: 'output_execpath_flags'
+    flag_set {
+      expand_if_all_available: 'output_execpath'
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: '/OUT:%{output_execpath}'
+      }
+    }
   }
 
   feature {
-     name: 'linkstamps'
-     flag_set {
-         action: 'c++-link-executable'
-         action: 'c++-link-dynamic-library'
-         expand_if_all_available: 'linkstamp_paths'
-         flag_group {
-             flag: '%{linkstamp_paths}'
-         }
-     }
-  }
-
-  feature {
-     name: 'output_execpath_flags'
-     flag_set {
-         expand_if_all_available: 'output_execpath'
-         action: 'c++-link-executable'
-         action: 'c++-link-dynamic-library'
-         flag_group {
-             flag: '/OUT:%{output_execpath}'
-         }
-     }
+    name: 'archiver_flags'
+    flag_set {
+      expand_if_all_available: 'output_execpath'
+      action: 'c++-link-static-library'
+      flag_group {
+        flag: '/OUT:%{output_execpath}'
+      }
+    }
   }
 
   feature {
     name: 'input_param_flags'
     flag_set {
-      expand_if_all_available: 'library_search_directories'
-      action: 'c++-link-executable'
+      expand_if_all_available: 'interface_library_output_path'
       action: 'c++-link-dynamic-library'
-      action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
+      action: "c++-link-nodeps-dynamic-library"
       flag_group {
-        iterate_over: 'library_search_directories'
-        flag: "-L%{library_search_directories}"
+        flag: "/IMPLIB:%{interface_library_output_path}"
       }
     }
     flag_set {
       expand_if_all_available: 'libopts'
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
-      action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
+      action: "c++-link-nodeps-dynamic-library"
       flag_group {
-          flag: '%{libopts}'
+        iterate_over: 'libopts'
+        flag: '%{libopts}'
       }
     }
     flag_set {
       expand_if_all_available: 'libraries_to_link'
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
       action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
         iterate_over: 'libraries_to_link'
         flag_group {
@@ -627,18 +740,54 @@ toolchain {
     }
   }
 
+  # Since this feature is declared earlier in the CROSSTOOL than
+  # "user_link_flags", this feature will be applied prior to it anwyhere they
+  # are both implied. And since "user_link_flags" contains the linkopts from
+  # the build rule, this allows the user to override the /SUBSYSTEM in the BUILD
+  # file.
+  feature {
+    name: 'linker_subsystem_flag'
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: '/SUBSYSTEM:CONSOLE'
+      }
+    }
+  }
+
+  # The "user_link_flags" contains user-defined linkopts (from build rules)
+  # so it should be defined after features that declare user-overridable flags.
+  # For example the "linker_subsystem_flag" defines a default "/SUBSYSTEM" flag
+  # but we want to let the user override it, therefore "link_flag_subsystem" is
+  # defined earlier in the CROSSTOOL file than "user_link_flags".
+  feature {
+    name: 'user_link_flags'
+    flag_set {
+      expand_if_all_available: 'user_link_flags'
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        iterate_over: 'user_link_flags'
+        flag: '%{user_link_flags}'
+      }
+    }
+  }
   feature {
     name: 'legacy_link_flags'
     flag_set {
       expand_if_all_available: 'legacy_link_flags'
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
       flag_group {
+        iterate_over: 'legacy_link_flags'
         flag: '%{legacy_link_flags}'
       }
     }
   }
-
 
   feature {
     name: 'linker_param_file'
@@ -646,47 +795,302 @@ toolchain {
       expand_if_all_available: 'linker_param_file'
       action: 'c++-link-executable'
       action: 'c++-link-dynamic-library'
-      flag_group {
-        flag: '-Wl,@%{linker_param_file}'
-      }
-    }
-    flag_set {
-      expand_if_all_available: 'linker_param_file'
+      action: "c++-link-nodeps-dynamic-library"
       action: 'c++-link-static-library'
-      action: 'c++-link-alwayslink-static-library'
-      action: 'c++-link-pic-static-library'
-      action: 'c++-link-alwayslink-pic-static-library'
       flag_group {
         flag: '@%{linker_param_file}'
       }
     }
   }
 
-  compilation_mode_flags {
-    mode: DBG
-    compiler_flag: "/DDEBUG=1"
-    # This will signal the wrapper that we are doing a debug build, which sets
-    # some internal state of the toolchain wrapper. It is intentionally a "-"
-    # flag to make this very obvious.
-    compiler_flag: "-g"
-    compiler_flag: "/Od"
-    compiler_flag: "-Xcompilation-mode=dbg"
-    linker_flag: "-Xcompilation-mode=dbg"
+  feature {
+    name: 'static_link_msvcrt'
   }
 
-  compilation_mode_flags {
-    mode: FASTBUILD
-    compiler_flag: "/DNDEBUG"
-    compiler_flag: "/Od"
-    compiler_flag: "-Xcompilation-mode=fastbuild"
-    linker_flag: "-Xcompilation-mode=fastbuild"
+  feature {
+    name: 'static_link_msvcrt_no_debug'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/MT"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "/DEFAULTLIB:libcmt.lib"
+      }
+    }
+    requires: { feature: 'fastbuild'}
+    requires: { feature: 'opt'}
   }
 
-  compilation_mode_flags {
-    mode: OPT
-    compiler_flag: "/DNDEBUG"
-    compiler_flag: "/O2"
-    compiler_flag: "-Xcompilation-mode=opt"
-    linker_flag: "-Xcompilation-mode=opt"
+  feature {
+    name: 'dynamic_link_msvcrt_no_debug'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/MD"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "/DEFAULTLIB:msvcrt.lib"
+      }
+    }
+    requires: { feature: 'fastbuild'}
+    requires: { feature: 'opt'}
   }
+
+  feature {
+    name: 'static_link_msvcrt_debug'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/MTd"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "/DEFAULTLIB:libcmtd.lib"
+      }
+    }
+    requires: { feature: 'dbg'}
+  }
+
+  feature {
+    name: 'dynamic_link_msvcrt_debug'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/MDd"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "/DEFAULTLIB:msvcrtd.lib"
+      }
+    }
+    requires: { feature: 'dbg'}
+  }
+
+  feature {
+    name: 'dbg'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/Od"
+        flag: "/Z7"
+        flag: "/DDEBUG"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "%{dbg_mode_debug}"
+        flag: "/INCREMENTAL:NO"
+      }
+    }
+    implies: 'generate_pdb_file'
+  }
+
+  feature {
+    name: 'fastbuild'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/Od"
+        flag: "/Z7"
+        flag: "/DDEBUG"
+      }
+    }
+    flag_set {
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "%{fastbuild_mode_debug}"
+        flag: "/INCREMENTAL:NO"
+      }
+    }
+    implies: 'generate_pdb_file'
+  }
+
+  feature {
+    name: 'opt'
+    flag_set {
+      action: 'c-compile'
+      action: 'c++-compile'
+      flag_group {
+        flag: "/O2"
+        flag: "/DNDEBUG"
+      }
+    }
+  }
+
+  feature {
+    name: 'user_compile_flags'
+    flag_set {
+      expand_if_all_available: 'user_compile_flags'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        iterate_over: 'user_compile_flags'
+        flag: '%{user_compile_flags}'
+      }
+    }
+  }
+
+  feature {
+    name: 'sysroot'
+    flag_set {
+      expand_if_all_available: 'sysroot'
+      action: 'assemble'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        iterate_over: 'sysroot'
+        flag: '--sysroot=%{sysroot}'
+      }
+    }
+  }
+
+  feature {
+    name: 'unfiltered_compile_flags'
+    flag_set {
+      expand_if_all_available: 'unfiltered_compile_flags'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        iterate_over: 'unfiltered_compile_flags'
+        flag: '%{unfiltered_compile_flags}'
+      }
+    }
+  }
+
+  feature {
+    name: 'compiler_output_flags'
+    flag_set {
+      action: 'assemble'
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_none_available: 'output_assembly_file'
+        expand_if_none_available: 'output_preprocess_file'
+        flag: '/Fo%{output_file}'
+        flag: '/Zi'
+      }
+    }
+    flag_set {
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_none_available: 'output_assembly_file'
+        expand_if_none_available: 'output_preprocess_file'
+        flag: '/Fo%{output_file}'
+      }
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_all_available: 'output_assembly_file'
+        flag: '/Fa%{output_file}'
+      }
+      flag_group {
+        expand_if_all_available: 'output_file'
+        expand_if_all_available: 'output_preprocess_file'
+        flag: '/P'
+        flag: '/Fi%{output_file}'
+      }
+    }
+  }
+
+  feature {
+    name: 'compiler_input_flags'
+    flag_set {
+      action: 'assemble'
+      action: 'preprocess-assemble'
+      action: 'c-compile'
+      action: 'c++-compile'
+      action: 'c++-header-parsing'
+      action: 'c++-header-preprocessing'
+      action: 'c++-module-compile'
+      action: 'c++-module-codegen'
+      flag_group {
+        expand_if_all_available: 'source_file'
+        flag: '/c'
+        flag: '%{source_file}'
+      }
+    }
+  }
+
+  feature {
+    name : 'def_file',
+    flag_set {
+      expand_if_all_available: 'def_file_path'
+      action: 'c++-link-executable'
+      action: 'c++-link-dynamic-library'
+      action: "c++-link-nodeps-dynamic-library"
+      flag_group {
+        flag: "/DEF:%{def_file_path}"
+        # We can specify a different DLL name in DEF file, /ignore:4070 suppresses
+        # the warning message about DLL name doesn't match the default one.
+        # See https://msdn.microsoft.com/en-us/library/sfkk2fz7.aspx
+        flag: "/ignore:4070"
+      }
+    }
+  }
+
+  feature {
+    name: 'windows_export_all_symbols'
+  }
+
+  feature {
+    name: 'no_windows_export_all_symbols'
+  }
+
+  linking_mode_flags { mode: DYNAMIC }
+
+%{compilation_mode_content}
+
 }

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Imported from https://github.com/bazelbuild/bazel/blob/master/tools/cpp/CROSSTOOL.tpl
+# with local modifications to integrate with LLVM.
 
 major_version: "local"
 minor_version: ""

--- a/tools/cpp/CROSSTOOL.tpl
+++ b/tools/cpp/CROSSTOOL.tpl
@@ -138,7 +138,6 @@ toolchain {
     mode: OPT
 %{opt_content}
   }
-  linking_mode_flags { mode: DYNAMIC }
 
 %{coverage}
 

--- a/tools/cpp/clang_configure.bzl
+++ b/tools/cpp/clang_configure.bzl
@@ -729,6 +729,8 @@ def _impl(repository_ctx):
         "%{content}": _get_windows_msys_crosstool_content(repository_ctx),
         "%{opt_content}": "",
         "%{dbg_content}": "",
+        "%{compilation_mode_content}": "",
+        "%{msys_x64_mingw_content}": "",
         "%{cxx_builtin_include_directory}": "\n".join(cxx_include_directories),
         "%{coverage}": "",
     })
@@ -759,6 +761,8 @@ def _impl(repository_ctx):
                       ("" if darwin else "linking_mode_flags { mode: DYNAMIC }\n"),
         "%{opt_content}": _build_crosstool(opt_content, "    "),
         "%{dbg_content}": _build_crosstool(dbg_content, "    "),
+        "%{compilation_mode_content}": "",
+        "%{msys_x64_mingw_content}": "",
         "%{cxx_builtin_include_directory}": "",
         "%{coverage}": _coverage_feature(darwin),
         "%{msvc_env_tmp}": "",
@@ -802,3 +806,4 @@ def clang_configure():
   """A C++ configuration rules that generate the crosstool file."""
   cc_autoconf(name="local_config_cc")
   native.bind(name="cc_toolchain", actual="@local_config_cc//:toolchain")
+  native.register_toolchains("@local_config_cc//:all")


### PR DESCRIPTION
This reworks how the cc_indexer_test rules get access to the configuration and builtin include libraries as well as updating to a newer version of CROSSTOOL.tpl.

Fragments are deprecated in favor of toolchains which aren't ready yet.

Accompanying this are some additional changes required for macOS.