### PR TITLE
Implement MarkedSource rendering once in the codebase per language.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/util/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/BUILD
@@ -66,6 +66,7 @@ java_library(
     name = "qualified_name_extractor",
     srcs = ["QualifiedNameExtractor.java"],
     deps = [
+        "//kythe/java/com/google/devtools/kythe/doc:marked_source_renderer",
         "//kythe/proto:common_java_proto",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/util/QualifiedNameExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/util/QualifiedNameExtractor.java
@@ -16,10 +16,10 @@
 
 package com.google.devtools.kythe.util;
 
+import com.google.devtools.kythe.doc.MarkedSourceRenderer;
 import com.google.devtools.kythe.proto.MarkedSource;
 import com.google.devtools.kythe.proto.SymbolInfo;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Provides a library of functions for extracting qualified names from java record/class marked
@@ -33,94 +33,14 @@ public class QualifiedNameExtractor {
    * @return a {@link SymbolInfo} message containing the extracted name.
    */
   public static Optional<SymbolInfo> extractNameFromMarkedSource(MarkedSource markedSource) {
-    // Extract the base name. Note that the base name may be at the root, so
-    // check for that case explicitly.
-    Optional<MarkedSource> identifier;
-    if (markedSourceMatches(
-        markedSource, MarkedSource.Kind.IDENTIFIER, /* isPretextRequired */ true)) {
-      identifier = Optional.of(markedSource);
-    } else {
-      identifier =
-          retrieveFirstMarkedSourceByKind(
-              markedSource, MarkedSource.Kind.IDENTIFIER, /* isPretextRequired */ true);
-    }
-    if (!identifier.isPresent()) {
-      // if the current class node's marked source does not contain an identifier, skip it
+    String identifier = MarkedSourceRenderer.renderSimpleIdentifierText(markedSource);
+    if (identifier.isEmpty()) {
       return Optional.empty();
     }
-    String baseName = identifier.get().getPreText();
-
-    // extract the class's package name
-    String qualifiedName = null;
-    Optional<MarkedSource> context =
-        retrieveFirstMarkedSourceByKind(
-            markedSource, MarkedSource.Kind.CONTEXT, /* isPretextRequired */ false);
-    if (context.isPresent()) {
-      String postChildText = context.get().getPostChildText();
-      String packageDelim = !postChildText.isEmpty() ? postChildText : ".";
-      String packageName =
-          String.join(
-              packageDelim,
-              context
-                  .get()
-                  .getChildList()
-                  .stream()
-                  .filter(
-                      child ->
-                          child.getKind().equals(MarkedSource.Kind.IDENTIFIER)
-                              && !child.getPreText().isEmpty())
-                  .map(MarkedSource::getPreText)
-                  .collect(Collectors.toList()));
-
-      if (!packageName.isEmpty()) {
-        qualifiedName = String.format("%s%s%s", packageName, postChildText, baseName);
-      }
-    }
-
-    // emit the symbol info
+    String qualifiedName = MarkedSourceRenderer.renderSimpleQualifiedNameText(markedSource, true);
     SymbolInfo.Builder symbolInfo = SymbolInfo.newBuilder();
-    symbolInfo.setBaseName(baseName);
-    if (qualifiedName != null) {
-      symbolInfo.setQualifiedName(qualifiedName);
-    }
-
+    symbolInfo.setBaseName(identifier);
+    symbolInfo.setQualifiedName(qualifiedName.equals(identifier) ? "" : qualifiedName);
     return Optional.of(symbolInfo.build());
-  }
-
-  /**
-   * Traverse the specified {@link MarkedSource} tree breadth-first, returning the first node that
-   * matches the specified kind.
-   *
-   * @param markedSource The root of the {@link MarkedSource} tree to be traversed.
-   * @param kind The kind of the requested node.
-   * @param isPretextRequired Whether or not the existence of a pretext string is required.
-   */
-  private static Optional<MarkedSource> retrieveFirstMarkedSourceByKind(
-      MarkedSource markedSource, MarkedSource.Kind kind, boolean isPretextRequired) {
-    // Check children explicitly before recurring; a match at this level should
-    // be preferred to a deeper match (breadth-first).
-    for (MarkedSource child : markedSource.getChildList()) {
-      if (markedSourceMatches(child, kind, isPretextRequired)) {
-        return Optional.of(child);
-      }
-    }
-
-    // Recur into children.
-    for (MarkedSource child : markedSource.getChildList()) {
-      Optional<MarkedSource> result =
-          retrieveFirstMarkedSourceByKind(child, kind, isPretextRequired);
-      if (result.isPresent()) {
-        return result;
-      }
-    }
-
-    return Optional.empty();
-  }
-
-  /** Report whether markedSource has the specified kind and required pre-text. */
-  private static boolean markedSourceMatches(
-      MarkedSource markedSource, MarkedSource.Kind kind, boolean isPretextRequired) {
-    return markedSource.getKind().equals(kind)
-        && (!isPretextRequired || !markedSource.getPreText().isEmpty());
   }
 }


### PR DESCRIPTION
QualifiedNameExtractor doesn't render MarkedSource the same way as
MarkedSourceRenderer (or the C++ renderer). To keep it from diverging
any further, teach MarkedSourceRenderer how to render plain text and
redirect QualifiedNameExtractor to use it.

Also remove a non-standard feature that uses "." as an implicit
separator in certain circumstances.