### PR TITLE
Bug fix: Avert a crash reading a nil proto field.

### DIFF
--- a/kythe/go/platform/kcd/kzipdb/kzipdb.go
+++ b/kythe/go/platform/kcd/kzipdb/kzipdb.go
@@ -41,7 +41,7 @@ func (db DB) Revisions(ctx context.Context, want *kcd.RevisionsFilter, f func(kc
 	seen := make(map[kcd.Revision]bool)
 	return db.Reader.Scan(func(unit *kzip.Unit) error {
 		corpus := unit.Proto.GetVName().GetCorpus()
-		for _, revision := range unit.Index.Revisions {
+		for _, revision := range unit.Index.GetRevisions() {
 			rev := kcd.Revision{Revision: revision, Corpus: corpus}
 			if !seen[rev] && revisionMatches(rev) {
 				if err := f(rev); err != nil {
@@ -66,7 +66,7 @@ func (db DB) Find(ctx context.Context, filter *kcd.FindFilter, f func(string) er
 	return db.Reader.Scan(func(unit *kzip.Unit) error {
 		idx := kythe.Unit{unit.Proto}.Index()
 
-		if cf.RevisionMatches(unit.Index.Revisions...) &&
+		if cf.RevisionMatches(unit.Index.GetRevisions()...) &&
 			cf.LanguageMatches(idx.Language) &&
 			cf.TargetMatches(idx.Target) &&
 			cf.OutputMatches(idx.Output) &&

--- a/kythe/go/platform/kcd/kzipdb/kzipdb_test.go
+++ b/kythe/go/platform/kcd/kzipdb/kzipdb_test.go
@@ -71,6 +71,7 @@ func setup(t *testing.T) {
 			{Unit: newUnit("C", "go", "chromium"), Index: newIndex("123")},
 			{Unit: newUnit("D", "protobuf", "kythe"), Index: newIndex("789")},
 			{Unit: newUnit("E", "java", "boiler.plate"), Index: newIndex("666")},
+			{Unit: newUnit("F", "java", "kythe")},
 		} {
 			digest, err := w.AddUnit(ic.Unit, ic.Index)
 			if err != nil {


### PR DESCRIPTION
Since the index field of an indexed compilation may legally be unset, use the
accessor to fetch its revisions list.