### PR TITLE
Combine *spb.Entry protos into *ppb.Nodes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -409,7 +409,7 @@ go_repository(
 
 go_repository(
     name = "com_github_apache_beam",
-    commit = "ff33e4c567460cf39a13b0c544b23da139571df1",
+    commit = "0ea97a562f82e98ff5cbe5a0825d298663112cdb",
     custom = "beam",
     importpath = "github.com/apache/beam",
 )

--- a/kythe/go/serving/pipeline/BUILD
+++ b/kythe/go/serving/pipeline/BUILD
@@ -4,13 +4,17 @@ package(default_visibility = ["//kythe:default_visibility"])
 
 go_library(
     name = "pipeline",
-    srcs = ["pipeline.go"],
+    srcs = [
+        "beam.go",
+        "pipeline.go",
+    ],
     deps = [
         "//kythe/go/services/filetree",
         "//kythe/go/services/graphstore",
         "//kythe/go/services/xrefs",
         "//kythe/go/serving/filetree",
         "//kythe/go/serving/graph",
+        "//kythe/go/serving/pipeline/nodes",
         "//kythe/go/serving/xrefs",
         "//kythe/go/serving/xrefs/assemble",
         "//kythe/go/storage/keyvalue",
@@ -25,6 +29,7 @@ go_library(
         "//kythe/proto:internal_go_proto",
         "//kythe/proto:serving_go_proto",
         "//kythe/proto:storage_go_proto",
+        "@com_github_apache_beam//sdks/go/pkg/beam:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/serving/pipeline/beam.go
+++ b/kythe/go/serving/pipeline/beam.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pipeline
+
+import (
+	"kythe.io/kythe/go/serving/pipeline/nodes"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+)
+
+// KytheBeam controls the lifetime and generation of PCollections in the Kythe
+// pipeline.
+type KytheBeam struct {
+	s beam.Scope
+
+	nodes beam.PCollection
+}
+
+// FromEntries creates a KytheBeam pipeline from an input collection of
+// *spb.Entry messages.
+func FromEntries(s beam.Scope, entries beam.PCollection) *KytheBeam {
+	return &KytheBeam{s: s, nodes: nodes.FromEntries(s, entries)}
+}
+
+// Nodes returns all *ppb.Nodes from the Kythe input graph.
+func (k *KytheBeam) Nodes() beam.PCollection { return k.nodes }

--- a/kythe/go/serving/pipeline/nodes/BUILD
+++ b/kythe/go/serving/pipeline/nodes/BUILD
@@ -1,0 +1,30 @@
+load("//tools:build_rules/shims.bzl", "go_library", "go_test")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+go_library(
+    name = "nodes",
+    srcs = ["nodes.go"],
+    deps = [
+        "//kythe/go/services/graphstore/compare",
+        "//kythe/go/util/schema",
+        "//kythe/go/util/schema/edges",
+        "//kythe/go/util/schema/facts",
+        "//kythe/proto:pipeline_go_proto",
+        "//kythe/proto:schema_go_proto",
+        "//kythe/proto:storage_go_proto",
+        "@com_github_apache_beam//sdks/go/pkg/beam:go_default_library",
+    ],
+)
+
+go_test(
+    name = "nodes_test",
+    srcs = ["nodes_test.go"],
+    library = ":nodes",
+    deps = [
+        "//kythe/go/util/schema/nodes",
+        "@com_github_apache_beam//sdks/go/pkg/beam/testing/passert:go_default_library",
+        "@com_github_apache_beam//sdks/go/pkg/beam/testing/ptest:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
+)

--- a/kythe/go/serving/pipeline/nodes/nodes.go
+++ b/kythe/go/serving/pipeline/nodes/nodes.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package nodes provides Beam transformations over *ppb.Nodes.
+package nodes
+
+import (
+	"reflect"
+	"sort"
+
+	"kythe.io/kythe/go/services/graphstore/compare"
+	"kythe.io/kythe/go/util/schema"
+	"kythe.io/kythe/go/util/schema/edges"
+	"kythe.io/kythe/go/util/schema/facts"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+
+	ppb "kythe.io/kythe/proto/pipeline_go_proto"
+	scpb "kythe.io/kythe/proto/schema_go_proto"
+	spb "kythe.io/kythe/proto/storage_go_proto"
+)
+
+func init() {
+	beam.RegisterFunction(embedSourceKey)
+	beam.RegisterFunction(entryToNode)
+
+	beam.RegisterType(reflect.TypeOf((*combineNodes)(nil)).Elem())
+}
+
+// FromEntries transforms a PCollection of *ppb.Entry protos into *ppb.Nodes.
+func FromEntries(s beam.Scope, entries beam.PCollection) beam.PCollection {
+	return beam.ParDo(s, embedSourceKey,
+		beam.CombinePerKey(s, &combineNodes{},
+			beam.ParDo(s, entryToNode, entries)))
+}
+
+func entryToNode(e *spb.Entry) (*spb.VName, *ppb.Node) {
+	n := &ppb.Node{}
+	if e.EdgeKind == "" {
+		switch e.FactName {
+		case facts.NodeKind:
+			kind := string(e.FactValue)
+			if k := schema.NodeKind(kind); k != scpb.NodeKind_UNKNOWN_NODE_KIND {
+				n.Kind = &ppb.Node_KytheKind{k}
+			} else {
+				n.Kind = &ppb.Node_GenericKind{kind}
+			}
+		case facts.Subkind:
+			subkind := string(e.FactValue)
+			if k := schema.Subkind(subkind); k != scpb.Subkind_UNKNOWN_SUBKIND {
+				n.Subkind = &ppb.Node_KytheSubkind{k}
+			} else {
+				n.Subkind = &ppb.Node_GenericSubkind{subkind}
+			}
+		default:
+			n.Fact = append(n.Fact, entryToFact(e))
+		}
+	} else {
+		n.Edge = append(n.Edge, entryToEdge(e))
+	}
+	return e.Source, n
+}
+
+func entryToEdge(e *spb.Entry) *ppb.Edge {
+	kind, ord, _ := edges.ParseOrdinal(e.EdgeKind)
+	g := &ppb.Edge{Target: e.Target, Ordinal: int32(ord)}
+	edgeKind := schema.EdgeKind(kind)
+	if edgeKind == scpb.EdgeKind_UNKNOWN_EDGE_KIND {
+		g.Kind = &ppb.Edge_GenericKind{kind}
+	} else {
+		g.Kind = &ppb.Edge_KytheKind{edgeKind}
+	}
+	return g
+}
+
+func entryToFact(e *spb.Entry) *ppb.Fact {
+	f := &ppb.Fact{Value: e.FactValue}
+	name := schema.FactName(e.FactName)
+	if name == scpb.FactName_UNKNOWN_FACT_NAME {
+		f.Name = &ppb.Fact_GenericName{e.FactName}
+	} else {
+		f.Name = &ppb.Fact_KytheName{name}
+	}
+	return f
+}
+
+type combineNodes struct{}
+
+func (combineNodes) CreateAccumulator() *ppb.Node { return &ppb.Node{} }
+
+func (c *combineNodes) MergeAccumulators(accum, n *ppb.Node) *ppb.Node {
+	if n.Kind != nil {
+		accum.Kind = n.Kind
+	}
+	if n.Subkind != nil {
+		accum.Subkind = n.Subkind
+	}
+	for _, f := range n.Fact {
+		accum.Fact = append(accum.Fact, f)
+	}
+	for _, e := range n.Edge {
+		accum.Edge = append(accum.Edge, e)
+	}
+	return accum
+}
+
+func (c *combineNodes) AddInput(accum, n *ppb.Node) *ppb.Node { return c.MergeAccumulators(accum, n) }
+
+func (c *combineNodes) ExtractOutput(n *ppb.Node) *ppb.Node {
+	// TODO(schroederc): deduplicate earlier during combine
+	if len(n.Fact) > 1 {
+		sort.Slice(n.Fact, func(i, j int) bool { return compareFacts(n.Fact[i], n.Fact[j]) == compare.LT })
+		j := 1
+		for i := 1; i < len(n.Fact); i++ {
+			if compareFacts(n.Fact[j-1], n.Fact[i]) != compare.EQ {
+				n.Fact[j] = n.Fact[i]
+				j++
+				i++
+			}
+		}
+		n.Fact = n.Fact[:j]
+	}
+	if len(n.Edge) > 1 {
+		sort.Slice(n.Edge, func(i, j int) bool { return compareEdges(n.Edge[i], n.Edge[j]) == compare.LT })
+		j := 1
+		for i := 1; i < len(n.Edge); i++ {
+			if compareEdges(n.Edge[j-1], n.Edge[i]) != compare.EQ {
+				n.Edge[j] = n.Edge[i]
+				j++
+				i++
+			}
+		}
+		n.Edge = n.Edge[:j]
+	}
+	return n
+}
+
+func compareFacts(a, b *ppb.Fact) compare.Order {
+	c := compare.Ints(int(a.GetKytheName()), int(b.GetKytheName()))
+	if c != compare.EQ {
+		return c
+	}
+	return compare.Strings(a.GetGenericName(), b.GetGenericName())
+}
+
+func compareEdges(a, b *ppb.Edge) compare.Order {
+	if c := compare.Ints(int(a.GetKytheKind()), int(b.GetKytheKind())); c != compare.EQ {
+		return c
+	} else if c := compare.Strings(a.GetGenericKind(), b.GetGenericKind()); c != compare.EQ {
+		return c
+	} else if c := compare.Ints(int(a.Ordinal), int(b.Ordinal)); c != compare.EQ {
+		return c
+	}
+	return compare.VNames(a.Target, b.Target)
+}
+
+func embedSourceKey(src *spb.VName, n *ppb.Node) *ppb.Node {
+	return &ppb.Node{
+		Source:  src,
+		Kind:    n.Kind,
+		Subkind: n.Subkind,
+		Fact:    n.Fact,
+		Edge:    n.Edge,
+	}
+}

--- a/kythe/go/serving/pipeline/nodes/nodes_test.go
+++ b/kythe/go/serving/pipeline/nodes/nodes_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodes
+
+import (
+	"testing"
+
+	"kythe.io/kythe/go/util/schema/edges"
+	"kythe.io/kythe/go/util/schema/facts"
+	"kythe.io/kythe/go/util/schema/nodes"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
+	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
+
+	ppb "kythe.io/kythe/proto/pipeline_go_proto"
+	scpb "kythe.io/kythe/proto/schema_go_proto"
+	spb "kythe.io/kythe/proto/storage_go_proto"
+)
+
+func TestFromEntries(t *testing.T) {
+	entries := []*spb.Entry{{
+		Source:    &spb.VName{Signature: "node1"},
+		FactName:  facts.NodeKind,
+		FactValue: []byte(nodes.Record),
+	}, {
+		Source:    &spb.VName{Signature: "node1"},
+		FactName:  facts.Subkind,
+		FactValue: []byte(nodes.Class),
+	}, {
+		Source:    &spb.VName{Signature: "node2"},
+		FactName:  facts.NodeKind,
+		FactValue: []byte("unknown_nodekind"),
+	}, {
+		Source:    &spb.VName{Signature: "node2"},
+		FactName:  facts.Subkind,
+		FactValue: []byte("unknown_subkind"),
+	}, {
+		Source:    &spb.VName{Signature: "node2"},
+		FactName:  facts.Text, // schema-known fact name
+		FactValue: []byte("text"),
+	}, {
+		// Duplicate fact
+		Source:    &spb.VName{Signature: "node2"},
+		FactName:  facts.Text,
+		FactValue: []byte("text"),
+	}, {
+		Source:    &spb.VName{Signature: "node2"},
+		FactName:  "/unknown/fact/name",
+		FactValue: []byte("blah"),
+	}, {
+		Source:   &spb.VName{Signature: "node2"},
+		EdgeKind: edges.Typed, // schema-known edge kind
+		Target:   &spb.VName{Signature: "node1"},
+	}, {
+		// Duplicate edge
+		Source:   &spb.VName{Signature: "node2"},
+		EdgeKind: edges.Typed,
+		Target:   &spb.VName{Signature: "node1"},
+	}, {
+		Source:   &spb.VName{Signature: "node2"},
+		EdgeKind: "/unknown/edge/kind",
+		Target:   &spb.VName{Signature: "node2"},
+	}}
+	expected := []*ppb.Node{{
+		Source:  &spb.VName{Signature: "node1"},
+		Kind:    &ppb.Node_KytheKind{scpb.NodeKind_RECORD},
+		Subkind: &ppb.Node_KytheSubkind{scpb.Subkind_CLASS},
+	}, {
+		Source:  &spb.VName{Signature: "node2"},
+		Kind:    &ppb.Node_GenericKind{"unknown_nodekind"},
+		Subkind: &ppb.Node_GenericSubkind{"unknown_subkind"},
+		Fact: []*ppb.Fact{{
+			Name:  &ppb.Fact_KytheName{scpb.FactName_TEXT},
+			Value: []byte("text"),
+		}, {
+			Name:  &ppb.Fact_GenericName{"/unknown/fact/name"},
+			Value: []byte("blah"),
+		}},
+		Edge: []*ppb.Edge{{
+			Kind:   &ppb.Edge_KytheKind{scpb.EdgeKind_TYPED},
+			Target: &spb.VName{Signature: "node1"},
+		}, {
+			Kind:   &ppb.Edge_GenericKind{"/unknown/edge/kind"},
+			Target: &spb.VName{Signature: "node2"},
+		}},
+	}}
+
+	p, s := beam.NewPipelineWithRoot()
+	nodes := FromEntries(s, beam.CreateList(s, entries))
+	passert.Equals(s, nodes, beam.CreateList(s, expected))
+
+	if err := ptest.Run(p); err != nil {
+		t.Fatalf("Pipeline error: %+v", err)
+	}
+}

--- a/kythe/go/serving/tools/write_tables/write_tables.go
+++ b/kythe/go/serving/tools/write_tables/write_tables.go
@@ -140,6 +140,7 @@ func runExperimentalBeamPipeline(ctx context.Context) error {
 	}
 
 	p, s := beam.NewPipelineWithRoot()
-	beamio.ReadEntries(s, *entriesFile)
+	entries := beamio.ReadEntries(s, *entriesFile)
+	pipeline.FromEntries(s, entries)
 	return beamx.Run(ctx, p)
 }

--- a/kythe/proto/BUILD
+++ b/kythe/proto/BUILD
@@ -540,3 +540,20 @@ go_proto_library(
     importpath = "kythe.io/kythe/proto/extraction_config_go_proto",
     proto = ":extraction_config_proto",
 )
+
+proto_library(
+    name = "pipeline_proto",
+    srcs = ["pipeline.proto"],
+    deps = [
+        ":schema_proto",
+        ":storage_proto",
+    ],
+)
+
+go_kythe_proto(
+    proto = ":pipeline_proto",
+    deps = [
+        ":schema_go_proto",
+        ":storage_go_proto",
+    ],
+)

--- a/kythe/proto/pipeline.proto
+++ b/kythe/proto/pipeline.proto
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package kythe.proto.pipeline;
+
+option java_package = "com.google.devtools.kythe.proto";
+
+import "kythe/proto/schema.proto";
+import "kythe/proto/storage.proto";
+
+// A Node represents a Kythe graph node with all its known facts and edges.
+message Node {
+  kythe.proto.VName source = 1;
+
+  repeated Fact fact = 2;
+  repeated Edge edge = 3;
+
+  oneof kind {
+    kythe.proto.schema.NodeKind kythe_kind = 4;
+    string generic_kind = 5;
+  }
+  oneof subkind {
+    kythe.proto.schema.Subkind kythe_subkind = 6;
+    string generic_subkind = 7;
+  }
+}
+
+// A Fact represents a single Kythe graph node fact.
+message Fact {
+  kythe.proto.VName source = 1;
+
+  oneof name {
+    kythe.proto.schema.FactName kythe_name = 2;
+    string generic_name = 3;
+  }
+
+  bytes value = 4;
+}
+
+// An Edge represents a single Kythe graph edge.
+message Edge {
+  kythe.proto.VName source = 1;
+  kythe.proto.VName target = 2;
+
+  oneof kind {
+    kythe.proto.schema.EdgeKind kythe_kind = 3;
+    string generic_kind = 4;
+  }
+  int32 ordinal = 5;
+}


### PR DESCRIPTION
Nodes will be the basic input for the rest of the Kythe pipeline.  While
combining entries, duplicate edges/fact_values are discarded and known
schema strings are stored as enums.