### PR TITLE
Make the schema package support "go get" again.

### DIFF
--- a/kythe/go/util/schema/BUILD
+++ b/kythe/go/util/schema/BUILD
@@ -1,4 +1,4 @@
-load("//tools:build_rules/shims.bzl", "go_test", "go_library")
+load("//tools:build_rules/shims.bzl", "go_binary", "go_library", "go_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -20,13 +20,45 @@ genrule(
     name = "schema_index",
     srcs = ["//kythe/data:schema_index.textproto"],
     outs = ["schema_index.go"],
-    cmd = "{ " + "\n".join([
-        "echo 'package schema'",
-        "echo -n 'const indexTextPB = `'",
-        "cat $(location //kythe/data:schema_index.textproto)",
-        "echo '`'",
-    ]) + "\n }  > $@",
+    cmd = " ".join([
+        "$(location :mkdata) -package schema",
+        "-input '$(location //kythe/data:schema_index.textproto)'",
+        "-output '$@'",
+    ]),
+    tools = [":mkdata"],
     visibility = ["//visibility:private"],
+)
+
+# This rule verifies that the checked-in version of indexdata.go matches the
+# generated version used by the Bazel rule. It will fail to build if the two
+# differ.
+#
+# To fix it when it fails, run: update_data.sh
+genrule(
+    name = "schema_index_sync",
+    testonly = True,
+    srcs = [
+        "indexdata.go",
+        ":schema_index",
+    ],
+    outs = ["schema_index_sync.sh"],
+    cmd = " ".join([
+        "diff -q '$(location :schema_index)' '$(location :indexdata.go)';",
+        "echo \"exit $$?\" > $@",
+    ]),
+    executable = True,
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "mkdata",
+    srcs = ["mkdata/mkdata.go"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//kythe/proto:schema_go_proto",
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
+    ],
 )
 
 go_test(

--- a/kythe/go/util/schema/BUILD
+++ b/kythe/go/util/schema/BUILD
@@ -29,11 +29,6 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
-# This rule verifies that the checked-in version of indexdata.go matches the
-# generated version used by the Bazel rule. It will fail to build if the two
-# differ.
-#
-# To fix it when it fails, run: update_data.sh
 genrule(
     name = "schema_index_sync",
     testonly = True,
@@ -42,12 +37,23 @@ genrule(
         ":schema_index",
     ],
     outs = ["schema_index_sync.sh"],
-    cmd = " ".join([
-        "diff -q '$(location :schema_index)' '$(location :indexdata.go)';",
+    cmd = "\n".join([
+        "set +o pipefail",
+        "diff -q '$(location :schema_index)' '$(location :indexdata.go)'",
         "echo \"exit $$?\" > $@",
     ]),
     executable = True,
     visibility = ["//visibility:private"],
+)
+
+# This test verifies that the checked-in version of indexdata.go matches the
+# generated version used by the Bazel rule. It will fail to build if the two
+# differ.
+#
+# To fix it when it fails, run update_data.sh
+sh_test(
+    name = "schema_index_test",
+    srcs = [":schema_index_sync"],
 )
 
 go_binary(

--- a/kythe/go/util/schema/BUILD
+++ b/kythe/go/util/schema/BUILD
@@ -1,4 +1,5 @@
 load("//tools:build_rules/shims.bzl", "go_binary", "go_library", "go_test")
+load("//tools:build_rules/testing.bzl", "file_diff_test")
 
 package(default_visibility = ["//kythe:default_visibility"])
 
@@ -29,31 +30,14 @@ genrule(
     visibility = ["//visibility:private"],
 )
 
-genrule(
-    name = "schema_index_sync",
-    testonly = True,
-    srcs = [
-        "indexdata.go",
-        ":schema_index",
-    ],
-    outs = ["schema_index_sync.sh"],
-    cmd = "\n".join([
-        "set +o pipefail",
-        "diff -q '$(location :schema_index)' '$(location :indexdata.go)'",
-        "echo \"exit $$?\" > $@",
-    ]),
-    executable = True,
-    visibility = ["//visibility:private"],
-)
-
 # This test verifies that the checked-in version of indexdata.go matches the
 # generated version used by the Bazel rule. It will fail to build if the two
 # differ.
-#
-# To fix it when it fails, run update_data.sh
-sh_test(
+file_diff_test(
     name = "schema_index_test",
-    srcs = [":schema_index_sync"],
+    file1 = "indexdata.go",
+    file2 = ":schema_index",
+    message = "Run update_data.sh to sync indexdata.go with changes",
 )
 
 go_binary(

--- a/kythe/go/util/schema/indexdata.go
+++ b/kythe/go/util/schema/indexdata.go
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+// This is a generated file -- do not edit it by hand.
+// Input file: kythe/data/schema_index.textproto
+
+import scpb "kythe.io/kythe/proto/schema_go_proto"
+
+var (
+	nodeKinds = map[string]scpb.NodeKind{
+		"abs":        1,
+		"absvar":     2,
+		"anchor":     3,
+		"constant":   4,
+		"diagnostic": 5,
+		"doc":        6,
+		"file":       7,
+		"function":   9,
+		"interface":  8,
+		"lookup":     10,
+		"macro":      11,
+		"meta":       12,
+		"name":       13,
+		"package":    14,
+		"process":    15,
+		"record":     16,
+		"sum":        17,
+		"symbol":     18,
+		"talias":     19,
+		"tapp":       20,
+		"tbuiltin":   21,
+		"tnominal":   22,
+		"tsigma":     23,
+		"variable":   24,
+		"vcs":        25,
+	}
+
+	subkinds = map[string]scpb.Subkind{
+		"category":        1,
+		"class":           2,
+		"constructor":     3,
+		"destructor":      4,
+		"enum":            5,
+		"enumClass":       6,
+		"field":           7,
+		"implicit":        8,
+		"import":          9,
+		"initializer":     10,
+		"local":           11,
+		"local/parameter": 12,
+		"method":          13,
+		"namespace":       14,
+		"struct":          15,
+		"type":            16,
+		"union":           17,
+	}
+
+	factNames = map[string]scpb.FactName{
+		"/kythe/code":          1,
+		"/kythe/complete":      2,
+		"/kythe/context/url":   3,
+		"/kythe/details":       4,
+		"/kythe/doc/uri":       5,
+		"/kythe/label":         6,
+		"/kythe/loc/end":       7,
+		"/kythe/loc/start":     8,
+		"/kythe/message":       9,
+		"/kythe/node/kind":     10,
+		"/kythe/param/default": 11,
+		"/kythe/ruleclass":     12,
+		"/kythe/snippet/end":   13,
+		"/kythe/snippet/start": 14,
+		"/kythe/subkind":       15,
+		"/kythe/text":          16,
+		"/kythe/text/encoding": 17,
+		"/kythe/visibility":    18,
+	}
+
+	edgeKinds = map[string]scpb.EdgeKind{
+		"/kythe/edge/aliases":                  1,
+		"/kythe/edge/aliases/root":             2,
+		"/kythe/edge/annotatedby":              3,
+		"/kythe/edge/bounded/lower":            4,
+		"/kythe/edge/bounded/upper":            5,
+		"/kythe/edge/childof":                  6,
+		"/kythe/edge/childof/context":          7,
+		"/kythe/edge/completes":                8,
+		"/kythe/edge/completes/uniquely":       9,
+		"/kythe/edge/defines":                  10,
+		"/kythe/edge/defines/binding":          11,
+		"/kythe/edge/depends":                  12,
+		"/kythe/edge/documents":                13,
+		"/kythe/edge/exports":                  14,
+		"/kythe/edge/extends":                  15,
+		"/kythe/edge/generates":                16,
+		"/kythe/edge/imputes":                  17,
+		"/kythe/edge/instantiates":             18,
+		"/kythe/edge/instantiates/speculative": 19,
+		"/kythe/edge/named":                    20,
+		"/kythe/edge/overrides":                21,
+		"/kythe/edge/overrides/root":           22,
+		"/kythe/edge/overrides/transitive":     23,
+		"/kythe/edge/param":                    24,
+		"/kythe/edge/ref":                      25,
+		"/kythe/edge/ref/call":                 26,
+		"/kythe/edge/ref/call/implicit":        27,
+		"/kythe/edge/ref/doc":                  28,
+		"/kythe/edge/ref/expands":              29,
+		"/kythe/edge/ref/expands/transitive":   30,
+		"/kythe/edge/ref/file":                 31,
+		"/kythe/edge/ref/implicit":             32,
+		"/kythe/edge/ref/imports":              33,
+		"/kythe/edge/ref/includes":             34,
+		"/kythe/edge/ref/init":                 35,
+		"/kythe/edge/ref/init/implicit":        36,
+		"/kythe/edge/ref/queries":              37,
+		"/kythe/edge/satisfies":                38,
+		"/kythe/edge/specializes":              39,
+		"/kythe/edge/specializes/speculative":  40,
+		"/kythe/edge/tagged":                   41,
+		"/kythe/edge/typed":                    42,
+		"/kythe/edge/undefines":                43,
+	}
+
+	nodeKindsRev = map[scpb.NodeKind]string{
+		1:  "abs",
+		2:  "absvar",
+		3:  "anchor",
+		4:  "constant",
+		5:  "diagnostic",
+		6:  "doc",
+		7:  "file",
+		8:  "interface",
+		9:  "function",
+		10: "lookup",
+		11: "macro",
+		12: "meta",
+		13: "name",
+		14: "package",
+		15: "process",
+		16: "record",
+		17: "sum",
+		18: "symbol",
+		19: "talias",
+		20: "tapp",
+		21: "tbuiltin",
+		22: "tnominal",
+		23: "tsigma",
+		24: "variable",
+		25: "vcs",
+	}
+
+	subkindsRev = map[scpb.Subkind]string{
+		1:  "category",
+		2:  "class",
+		3:  "constructor",
+		4:  "destructor",
+		5:  "enum",
+		6:  "enumClass",
+		7:  "field",
+		8:  "implicit",
+		9:  "import",
+		10: "initializer",
+		11: "local",
+		12: "local/parameter",
+		13: "method",
+		14: "namespace",
+		15: "struct",
+		16: "type",
+		17: "union",
+	}
+
+	factNamesRev = map[scpb.FactName]string{
+		1:  "/kythe/code",
+		2:  "/kythe/complete",
+		3:  "/kythe/context/url",
+		4:  "/kythe/details",
+		5:  "/kythe/doc/uri",
+		6:  "/kythe/label",
+		7:  "/kythe/loc/end",
+		8:  "/kythe/loc/start",
+		9:  "/kythe/message",
+		10: "/kythe/node/kind",
+		11: "/kythe/param/default",
+		12: "/kythe/ruleclass",
+		13: "/kythe/snippet/end",
+		14: "/kythe/snippet/start",
+		15: "/kythe/subkind",
+		16: "/kythe/text",
+		17: "/kythe/text/encoding",
+		18: "/kythe/visibility",
+	}
+
+	edgeKindsRev = map[scpb.EdgeKind]string{
+		1:  "/kythe/edge/aliases",
+		2:  "/kythe/edge/aliases/root",
+		3:  "/kythe/edge/annotatedby",
+		4:  "/kythe/edge/bounded/lower",
+		5:  "/kythe/edge/bounded/upper",
+		6:  "/kythe/edge/childof",
+		7:  "/kythe/edge/childof/context",
+		8:  "/kythe/edge/completes",
+		9:  "/kythe/edge/completes/uniquely",
+		10: "/kythe/edge/defines",
+		11: "/kythe/edge/defines/binding",
+		12: "/kythe/edge/depends",
+		13: "/kythe/edge/documents",
+		14: "/kythe/edge/exports",
+		15: "/kythe/edge/extends",
+		16: "/kythe/edge/generates",
+		17: "/kythe/edge/imputes",
+		18: "/kythe/edge/instantiates",
+		19: "/kythe/edge/instantiates/speculative",
+		20: "/kythe/edge/named",
+		21: "/kythe/edge/overrides",
+		22: "/kythe/edge/overrides/root",
+		23: "/kythe/edge/overrides/transitive",
+		24: "/kythe/edge/param",
+		25: "/kythe/edge/ref",
+		26: "/kythe/edge/ref/call",
+		27: "/kythe/edge/ref/call/implicit",
+		28: "/kythe/edge/ref/doc",
+		29: "/kythe/edge/ref/expands",
+		30: "/kythe/edge/ref/expands/transitive",
+		31: "/kythe/edge/ref/file",
+		32: "/kythe/edge/ref/implicit",
+		33: "/kythe/edge/ref/imports",
+		34: "/kythe/edge/ref/includes",
+		35: "/kythe/edge/ref/init",
+		36: "/kythe/edge/ref/init/implicit",
+		37: "/kythe/edge/ref/queries",
+		38: "/kythe/edge/satisfies",
+		39: "/kythe/edge/specializes",
+		40: "/kythe/edge/specializes/speculative",
+		41: "/kythe/edge/tagged",
+		42: "/kythe/edge/typed",
+		43: "/kythe/edge/undefines",
+	}
+)
+
+// NodeKind returns the schema enum for the given node kind.
+func NodeKind(k string) scpb.NodeKind { return nodeKinds[k] }
+
+// EdgeKind returns the schema enum for the given edge kind.
+func EdgeKind(k string) scpb.EdgeKind { return edgeKinds[k] }
+
+// FactName returns the schema enum for the given fact name.
+func FactName(f string) scpb.FactName { return factNames[f] }
+
+// Subkind returns the schema enum for the given subkind.
+func Subkind(k string) scpb.Subkind { return subkinds[k] }
+
+// NodeKindString returns the string representation of the given node kind.
+func NodeKindString(k scpb.NodeKind) string { return nodeKindsRev[k] }
+
+// EdgeKindString returns the string representation of the given edge kind.
+func EdgeKindString(k scpb.EdgeKind) string { return edgeKindsRev[k] }
+
+// FactNameString returns the string representation of the given fact name.
+func FactNameString(f scpb.FactName) string { return factNamesRev[f] }
+
+// SubkindString returns the string representation of the given subkind.
+func SubkindString(k scpb.Subkind) string { return subkindsRev[k] }

--- a/kythe/go/util/schema/mkdata/mkdata.go
+++ b/kythe/go/util/schema/mkdata/mkdata.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Program mkdata converts a text protobuf containing Kythe schema descriptors
 // into a Go source file that can be compiled into the schema package.
 package main
@@ -11,7 +27,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	"bitbucket.org/creachadair/stringset"
 	"github.com/golang/protobuf/proto"
@@ -48,8 +63,8 @@ func main() {
 
 	// Generate Go source text.
 	src := new(strings.Builder)
-	fmt.Fprintf(src, `/*
- * Copyright %s Google Inc. All rights reserved.
+	fmt.Fprintln(src, `/*
+ * Copyright 2018 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,8 +77,7 @@ func main() {
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-`, time.Now().Format("2006"))
+ */`)
 	fmt.Fprintf(src, "\n\npackage %s\n", *packageName)
 	fmt.Fprintf(src, `
 // This is a generated file -- do not edit it by hand.

--- a/kythe/go/util/schema/mkdata/mkdata.go
+++ b/kythe/go/util/schema/mkdata/mkdata.go
@@ -1,0 +1,212 @@
+// Program mkdata converts a text protobuf containing Kythe schema descriptors
+// into a Go source file that can be compiled into the schema package.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/format"
+	"io/ioutil"
+	"log"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"bitbucket.org/creachadair/stringset"
+	"github.com/golang/protobuf/proto"
+
+	scpb "kythe.io/kythe/proto/schema_go_proto"
+)
+
+var (
+	inputPath   = flag.String("input", "", "Path of input data file (textpb)")
+	outputPath  = flag.String("output", "", "Path of output source file (Go)")
+	packageName = flag.String("package", "schema", "Package name to generate")
+)
+
+func main() {
+	flag.Parse()
+	switch {
+	case *inputPath == "":
+		log.Fatal("You must provide a data -input path")
+	case *outputPath == "":
+		log.Fatal("You must provide a source -output path")
+	case *packageName == "":
+		log.Fatal("You must provide a source -package name")
+	}
+
+	// Read and decode the schema constants.
+	data, err := ioutil.ReadFile(*inputPath)
+	if err != nil {
+		log.Fatalf("Reading input data: %v", err)
+	}
+	var index scpb.Index
+	if err := proto.UnmarshalText(string(data), &index); err != nil {
+		log.Fatalf("Invalid schema data: %v", err)
+	}
+
+	// Generate Go source text.
+	src := new(strings.Builder)
+	fmt.Fprintf(src, `/*
+ * Copyright %s Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+`, time.Now().Format("2006"))
+	fmt.Fprintf(src, "\n\npackage %s\n", *packageName)
+	fmt.Fprintf(src, `
+// This is a generated file -- do not edit it by hand.
+// Input file: %s
+
+`, *inputPath)
+
+	fmt.Fprintln(src, `import scpb "kythe.io/kythe/proto/schema_go_proto"`)
+	fmt.Fprintln(src, `var (`)
+
+	fmt.Fprintln(src, "nodeKinds = map[string]scpb.NodeKind{")
+	nodeKindsRev := make(map[scpb.NodeKind]string)
+	for _, kinds := range index.NodeKinds {
+		for _, name := range stringset.FromKeys(kinds.NodeKind).Elements() {
+			enum := kinds.NodeKind[name]
+			fullName := kinds.Prefix + name
+			fmt.Fprintf(src, "%q: %d,\n", fullName, enum)
+			nodeKindsRev[enum] = fullName
+		}
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nsubkinds = map[string]scpb.Subkind{")
+	subkindsRev := make(map[scpb.Subkind]string)
+	for _, kinds := range index.Subkinds {
+		for _, name := range stringset.FromKeys(kinds.Subkind).Elements() {
+			enum := kinds.Subkind[name]
+			fullName := kinds.Prefix + name
+			fmt.Fprintf(src, "%q: %d,\n", fullName, enum)
+			subkindsRev[enum] = fullName
+		}
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nfactNames = map[string]scpb.FactName{")
+	factNamesRev := make(map[scpb.FactName]string)
+	for _, kinds := range index.FactNames {
+		for _, name := range stringset.FromKeys(kinds.FactName).Elements() {
+			enum := kinds.FactName[name]
+			fullName := kinds.Prefix + name
+			fmt.Fprintf(src, "%q: %d,\n", fullName, enum)
+			factNamesRev[enum] = fullName
+		}
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nedgeKinds = map[string]scpb.EdgeKind{")
+	edgeKindsRev := make(map[scpb.EdgeKind]string)
+	for _, kinds := range index.EdgeKinds {
+		for _, name := range stringset.FromKeys(kinds.EdgeKind).Elements() {
+			enum := kinds.EdgeKind[name]
+			fullName := kinds.Prefix + name
+			fmt.Fprintf(src, "%q: %d,\n", fullName, enum)
+			edgeKindsRev[enum] = fullName
+		}
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nnodeKindsRev = map[scpb.NodeKind]string{")
+	for _, kind := range sortedKeys(nodeKindsRev) {
+		enum := kind.(scpb.NodeKind)
+		name := nodeKindsRev[enum]
+		fmt.Fprintf(src, "%d: %q,\n", enum, name)
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nsubkindsRev = map[scpb.Subkind]string{")
+	for _, kind := range sortedKeys(subkindsRev) {
+		enum := kind.(scpb.Subkind)
+		name := subkindsRev[enum]
+		fmt.Fprintf(src, "%d: %q,\n", enum, name)
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nfactNamesRev = map[scpb.FactName]string{")
+	for _, kind := range sortedKeys(factNamesRev) {
+		enum := kind.(scpb.FactName)
+		name := factNamesRev[enum]
+		fmt.Fprintf(src, "%d: %q,\n", enum, name)
+	}
+	fmt.Fprintln(src, "}")
+
+	fmt.Fprintln(src, "\nedgeKindsRev = map[scpb.EdgeKind]string{")
+	for _, kind := range sortedKeys(edgeKindsRev) {
+		enum := kind.(scpb.EdgeKind)
+		name := edgeKindsRev[enum]
+		fmt.Fprintf(src, "%d: %q,\n", enum, name)
+	}
+	fmt.Fprintln(src, "}")
+	fmt.Fprintln(src, ")")
+
+	fmt.Fprintln(src, `
+// NodeKind returns the schema enum for the given node kind.
+func NodeKind(k string) scpb.NodeKind { return nodeKinds[k] }
+
+// EdgeKind returns the schema enum for the given edge kind.
+func EdgeKind(k string) scpb.EdgeKind { return edgeKinds[k] }
+
+// FactName returns the schema enum for the given fact name.
+func FactName(f string) scpb.FactName { return factNames[f] }
+
+// Subkind returns the schema enum for the given subkind.
+func Subkind(k string) scpb.Subkind { return subkinds[k] }
+
+// NodeKindString returns the string representation of the given node kind.
+func NodeKindString(k scpb.NodeKind) string { return nodeKindsRev[k] }
+
+// EdgeKindString returns the string representation of the given edge kind.
+func EdgeKindString(k scpb.EdgeKind) string { return edgeKindsRev[k] }
+
+// FactNameString returns the string representation of the given fact name.
+func FactNameString(f scpb.FactName) string { return factNamesRev[f] }
+
+// SubkindString returns the string representation of the given subkind.
+func SubkindString(k scpb.Subkind) string { return subkindsRev[k] }
+`)
+
+	// Format and write out the resulting program.
+	text, err := format.Source([]byte(src.String()))
+	if err != nil {
+		log.Fatalf("Formatting Go source: %v", err)
+	}
+	if err := ioutil.WriteFile(*outputPath, text, 0644); err != nil {
+		log.Fatalf("Writing Go output: %v", err)
+	}
+}
+
+var u32 = reflect.TypeOf(uint32(0))
+
+// sortedKeys returns a slice of the keys of v having type map[X]V, where X is
+// a type convertible to uint32 (e.g., a proto enumeration).  This function
+// will panic if v does not have an appropriate concrete type.  The concrete
+// type of each returned element remains X (not uint32).
+func sortedKeys(v interface{}) []interface{} {
+	keys := reflect.ValueOf(v).MapKeys()
+	sort.Slice(keys, func(i, j int) bool {
+		a := keys[i].Convert(u32).Interface().(uint32)
+		b := keys[j].Convert(u32).Interface().(uint32)
+		return a < b
+	})
+	vals := make([]interface{}, len(keys))
+	for i, key := range keys {
+		vals[i] = key.Interface()
+	}
+	return vals
+}

--- a/kythe/go/util/schema/schema.go
+++ b/kythe/go/util/schema/schema.go
@@ -20,9 +20,6 @@ package schema
 import (
 	"kythe.io/kythe/go/util/schema/facts"
 
-	"github.com/golang/protobuf/proto"
-
-	scpb "kythe.io/kythe/proto/schema_go_proto"
 	spb "kythe.io/kythe/proto/storage_go_proto"
 )
 
@@ -99,74 +96,3 @@ func (n *Node) ToEntries() []*spb.Entry {
 	}
 	return entries
 }
-
-var (
-	nodeKinds = make(map[string]scpb.NodeKind)
-	subkinds  = make(map[string]scpb.Subkind)
-	factNames = make(map[string]scpb.FactName)
-	edgeKinds = make(map[string]scpb.EdgeKind)
-
-	nodeKindsRev = make(map[scpb.NodeKind]string)
-	subkindsRev  = make(map[scpb.Subkind]string)
-	factNamesRev = make(map[scpb.FactName]string)
-	edgeKindsRev = make(map[scpb.EdgeKind]string)
-)
-
-func init() {
-	var index scpb.Index
-	if err := proto.UnmarshalText(indexTextPB, &index); err != nil {
-		panic(err)
-	}
-	for _, kinds := range index.NodeKinds {
-		for name, enum := range kinds.NodeKind {
-			name = kinds.Prefix + name
-			nodeKinds[name] = enum
-			nodeKindsRev[enum] = name
-		}
-	}
-	for _, kinds := range index.Subkinds {
-		for name, enum := range kinds.Subkind {
-			name = kinds.Prefix + name
-			subkinds[name] = enum
-			subkindsRev[enum] = name
-		}
-	}
-	for _, kinds := range index.FactNames {
-		for name, enum := range kinds.FactName {
-			name = kinds.Prefix + name
-			factNames[name] = enum
-			factNamesRev[enum] = name
-		}
-	}
-	for _, kinds := range index.EdgeKinds {
-		for name, enum := range kinds.EdgeKind {
-			name = kinds.Prefix + name
-			edgeKinds[name] = enum
-			edgeKindsRev[enum] = name
-		}
-	}
-}
-
-// NodeKind returns the schema enum for the given node kind.
-func NodeKind(k string) scpb.NodeKind { return nodeKinds[k] }
-
-// EdgeKind returns the schema enum for the given edge kind.
-func EdgeKind(k string) scpb.EdgeKind { return edgeKinds[k] }
-
-// FactName returns the schema enum for the given fact name.
-func FactName(f string) scpb.FactName { return factNames[f] }
-
-// Subkind returns the schema enum for the given subkind.
-func Subkind(k string) scpb.Subkind { return subkinds[k] }
-
-// NodeKindString returns the string representation of the given node kind.
-func NodeKindString(k scpb.NodeKind) string { return nodeKindsRev[k] }
-
-// EdgeKindString returns the string representation of the given edge kind.
-func EdgeKindString(k scpb.EdgeKind) string { return edgeKindsRev[k] }
-
-// FactNameString returns the string representation of the given fact name.
-func FactNameString(f scpb.FactName) string { return factNamesRev[f] }
-
-// SubkindString returns the string representation of the given subkind.
-func SubkindString(k scpb.Subkind) string { return subkindsRev[k] }

--- a/kythe/go/util/schema/update_data.sh
+++ b/kythe/go/util/schema/update_data.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+readonly output=kythe/go/util/schema/indexdata.go
+
+echo "-- Updating $output from Bazel ... " 1>&2
+set -x
+bazel build //kythe/go/util/schema:schema_index
+cp bazel-genfiles/kythe/go/util/schema/schema_index.go "$output"
+chmod 0644 "$output"

--- a/tools/build_rules/testing.bzl
+++ b/tools/build_rules/testing.bzl
@@ -1,4 +1,45 @@
-"""This module contains a tool for making shell tests."""
+"""This module defines macros for making shell tests."""
+
+def file_diff_test(name, file1, file2, message='', size='small', tags=[]):
+  """A macro to compare a source file with a generated counterpart.
+
+  This macro generates a sh_test that prints a diff and fails if file1 is not
+  the same as file2.
+
+  Args:
+    name: the name of the sh_test to create
+    file1: the left-hand file to compare
+    file2: the right-hand file to compare
+    message: optional message to print if the files differ
+    size: the size of the test
+    tags: tags for the sh_test rule
+  """
+  if file1 == '' or file2 == '':
+    fail('You must provide both "file1" and "file2"')
+
+  if message == '':
+    message = 'Files $(location %s) and $(location %s) differ' % (file1, file2)
+
+  gen = name + '_script'
+  native.genrule(
+      name = gen,
+      srcs = [file1, file2],
+      outs = [gen + '.sh'],
+      executable = True,
+      testonly = True,
+      visibility = ['//visibility:private'],
+      cmd = '\n'.join([
+          "if ! diff '$(location %s)' '$(location %s)' ; then" % (file1, file2),
+          "  echo 'printf \"\\n>> %s\\n\\n\" ; exit 1' > $@" % message,
+          "else",
+          "  echo 'exit 0' > $@",
+          "fi",
+      ]),
+  )
+  native.sh_test(
+      name = name,
+      srcs = [':'+gen],
+  )
 
 def shell_tool_test(name, script=[], scriptfile='', tools={}, data=[],
                     args=[], size='small', tags=[]):


### PR DESCRIPTION
Addresses #54.

Prior to this change, the schema package has some logic in schema.go that
depends on a Bazel-generated file. This prevents the package from being
go-gotten unless we check in that file. So we'll check a copy in.

To do this, update the existing genrule, which worked by concatenating the text
proto directly into a source file, with a tool that generates Go source that
doesn't require the text proto. The file emitted by the new tool is independent
of the rest of the package, and includes both the constant maps (read from the
text proto at compile time) and the functions that use them.  This also makes
it easier to update the file without invoking Bazel.

This change also adds a rule that will fail to build if the generated code used
by the Bazel rule for the schema library differs from the checked-in version of
the data file provided for users of "go get".

It also includes a script to bring things back into sync.