### PR TITLE
pack2kzip: Copy concurrently.

### DIFF
--- a/kythe/go/platform/tools/pack2kzip/BUILD
+++ b/kythe/go/platform/tools/pack2kzip/BUILD
@@ -12,5 +12,6 @@ go_binary(
         "//kythe/proto:analysis_go_proto",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@org_bitbucket_creachadair_stringset//:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )


### PR DESCRIPTION
Allowing writes to proceed concurrently with reads reduces copying time by
about half.  Copying a sample indexpack containing ~4700 compilation records
and ~15200 unique files gives:

Format: Dir     ZIP
======= ------- -------
Before: 4m34.8s 4m41.2s
After:  2m29.1s 2m27.7s
        -45%    -47%