### PR TITLE
kzip: Add proto dependencies for detail messages.

### DIFF
--- a/kythe/go/platform/kzip/BUILD
+++ b/kythe/go/platform/kzip/BUILD
@@ -8,6 +8,10 @@ go_library(
     deps = [
         "//kythe/go/platform/kcd/kythe",
         "//kythe/proto:analysis_go_proto",
+        "//kythe/proto:buildinfo_go_proto",
+        "//kythe/proto:cxx_go_proto",
+        "//kythe/proto:go_go_proto",
+        "//kythe/proto:java_go_proto",
         "@com_github_golang_protobuf//jsonpb:go_default_library",
     ],
 )

--- a/kythe/go/platform/kzip/kzip.go
+++ b/kythe/go/platform/kzip/kzip.go
@@ -81,6 +81,13 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 
 	apb "kythe.io/kythe/proto/analysis_go_proto"
+
+	// These are common detail messages used by Kythe compilations, and
+	// required for JSON (un)marshaling to work.
+	_ "kythe.io/kythe/proto/buildinfo_go_proto"
+	_ "kythe.io/kythe/proto/cxx_go_proto"
+	_ "kythe.io/kythe/proto/go_go_proto"
+	_ "kythe.io/kythe/proto/java_go_proto"
 )
 
 // A Reader permits reading and scanning compilation records and file contents


### PR DESCRIPTION
In order to encode/decode detail messages, the user of the package will require
these dependencies as well as the CompilationUnit itself.