### PR TITLE
Plumb size & tags attributes correctly in the file_diff_test macro.

### DIFF
--- a/tools/build_rules/testing.bzl
+++ b/tools/build_rules/testing.bzl
@@ -39,6 +39,8 @@ def file_diff_test(name, file1, file2, message='', size='small', tags=[]):
   native.sh_test(
       name = name,
       srcs = [':'+gen],
+      size = size,
+      tags = tags,
   )
 
 def shell_tool_test(name, script=[], scriptfile='', tools={}, data=[],


### PR DESCRIPTION
I put these attributes into the signature, but didn't manage to get them all
the way to the test.