### PR TITLE
Add kzip support to the gotool extractor.

### DIFF
--- a/kythe/go/extractors/cmd/gotool/BUILD
+++ b/kythe/go/extractors/cmd/gotool/BUILD
@@ -9,6 +9,7 @@ go_binary(
         "//kythe/go/extractors/golang",
         "//kythe/go/platform/indexpack",
         "//kythe/go/platform/kindex",
+        "//kythe/go/platform/kzip",
         "//kythe/go/platform/vfs",
         "//kythe/proto:analysis_go_proto",
         "@com_github_pborman_uuid//:go_default_library",

--- a/kythe/go/indexer/testdata/go_indexer_test.bzl
+++ b/kythe/go/indexer/testdata/go_indexer_test.bzl
@@ -62,7 +62,7 @@ def _emit_extractor_script(ctx, mode, script, output, srcs, deps, ipath, data):
   cmds.append(' '.join([
       ctx.files._extractor[-1].path,
       '-kindex',
-      '-output_dir', outdir,
+      '-output', outdir,
       '-goroot', goroot,
       '-gopath', tmpdir,
       '-extra_files', "'%s'" % ','.join(extras),
@@ -156,7 +156,7 @@ def _go_entries(ctx):
   )
   return [KytheEntries(files=depset(), compressed=depset([output]))]
 
-# Run the Kythe indexer on the output that results from a go_indexpack rule.
+# Run the Kythe indexer on the output that results from a go_extract rule.
 go_entries = rule(
     _go_entries,
     attrs = {


### PR DESCRIPTION
Allow the gotool extractor to write output to a kzip file in addition to
.kindex and indexpack format. Eventually we will get rid of the other two
formats, but for now this is just adding the new format.