### PR TITLE
Make FindSourceArgs return a new-style fixup.

### DIFF
--- a/kythe/go/extractors/bazel/extractor_test.go
+++ b/kythe/go/extractors/bazel/extractor_test.go
@@ -304,26 +304,24 @@ func TestFetchInputs(t *testing.T) {
 }
 
 func TestFindSourceArgs(t *testing.T) {
-	unit := &kindex.Compilation{
-		Proto: &apb.CompilationUnit{
-			RequiredInput: []*apb.CompilationUnit_FileInput{{
-				Info: &apb.FileInfo{Path: "a/b/c.go"},
-			}, {
-				Info: &apb.FileInfo{Path: "d/e/f.cc"},
-			}, {
-				Info: &apb.FileInfo{Path: "old"},
-			}},
-			SourceFile: []string{"old"},
-			// Matches:        no      yes, keep   yes, skip   no
-			Argument: []string{"blah", "a/b/c.go", "p/d/q.go", "quux"},
-		},
+	unit := &apb.CompilationUnit{
+		RequiredInput: []*apb.CompilationUnit_FileInput{{
+			Info: &apb.FileInfo{Path: "a/b/c.go"},
+		}, {
+			Info: &apb.FileInfo{Path: "d/e/f.cc"},
+		}, {
+			Info: &apb.FileInfo{Path: "old"},
+		}},
+		SourceFile: []string{"old"},
+		// Matches:        no      yes, keep   yes, skip   no
+		Argument: []string{"blah", "a/b/c.go", "p/d/q.go", "quux"},
 	}
 	// Results:      new         extant
 	want := []string{"a/b/c.go", "old"}
 
 	r := regexp.MustCompile(`\.go$`)
 	FindSourceArgs(r)(unit)
-	if got := unit.Proto.SourceFile; !reflect.DeepEqual(got, want) {
+	if got := unit.SourceFile; !reflect.DeepEqual(got, want) {
 		t.Errorf("FindSourceArgs: got %+q, want %+q", got, want)
 	}
 }

--- a/kythe/go/extractors/bazel/settings.go
+++ b/kythe/go/extractors/bazel/settings.go
@@ -197,7 +197,7 @@ func NewFromSettings(s Settings) (*Config, *xapb.ExtraActionInfo, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid source args regexp: %v", err)
 		}
-		config.Fixup = FindSourceArgs(r)
+		config.FixUnit = FindSourceArgs(r)
 	}
 
 	return config, info, nil

--- a/kythe/go/extractors/bazel/utils.go
+++ b/kythe/go/extractors/bazel/utils.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"kythe.io/kythe/go/platform/kindex"
 	"kythe.io/kythe/go/util/ptypes"
 	"kythe.io/kythe/go/util/vnameutil"
 
@@ -124,20 +123,20 @@ func AddDetail(unit *apb.CompilationUnit, msg proto.Message) error {
 // FindSourceArgs returns a fixup that scans the argument list of a compilation
 // unit for strings matching r. Any that are found, and which also match the
 // names of required input files, are added to the source files of the unit.
-func FindSourceArgs(r *regexp.Regexp) func(*kindex.Compilation) error {
-	return func(cu *kindex.Compilation) error {
+func FindSourceArgs(r *regexp.Regexp) func(*apb.CompilationUnit) error {
+	return func(cu *apb.CompilationUnit) error {
 		var inputs stringset.Set
-		for _, ri := range cu.Proto.RequiredInput {
+		for _, ri := range cu.RequiredInput {
 			inputs.Add(ri.Info.GetPath())
 		}
 
-		srcs := stringset.New(cu.Proto.SourceFile...)
-		for _, arg := range cu.Proto.Argument {
+		srcs := stringset.New(cu.SourceFile...)
+		for _, arg := range cu.Argument {
 			if r.MatchString(arg) && inputs.Contains(arg) {
 				srcs.Add(arg)
 			}
 		}
-		cu.Proto.SourceFile = srcs.Elements()
+		cu.SourceFile = srcs.Elements()
 		return nil
 	}
 }


### PR DESCRIPTION
As part of migrating to a fixup interface that uses the compilation unit
directly, update the FindSourceArgs constructor to return the new style.