### PR TITLE
typescript: update compiler to 2.8.3

### DIFF
--- a/kythe/typescript/package.json
+++ b/kythe/typescript/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@types/node": "^7.0.4",
     "source-map-support": "^0.4.11",
-    "typescript": "~2.7.2"
+    "typescript": "~2.8.3"
   },
   "license": "Apache-2.0"
 }

--- a/kythe/typescript/yarn.lock
+++ b/kythe/typescript/yarn.lock
@@ -16,6 +16,6 @@ source-map@^0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-typescript@~2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@~2.8.3:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"


### PR DESCRIPTION
There is no code change necessary to support TypeScript 2.8.3, but
this is the version used within Google so it's good to match just
to be sure.