### PR TITLE
Apply simplifications found by gofmt -s.

### DIFF
--- a/kythe/go/languageserver/document_test.go
+++ b/kythe/go/languageserver/document_test.go
@@ -26,21 +26,21 @@ import (
 func TestRangeMatching(t *testing.T) {
 	text := "abcdefg"
 	doc := newDocument([]*RefResolution{
-		&RefResolution{
+		{
 			ticket: "longest",
 			oldRange: lsp.Range{
 				Start: lsp.Position{Line: 0, Character: 0},
 				End:   lsp.Position{Line: 0, Character: 5},
 			},
 		},
-		&RefResolution{
+		{
 			ticket: "shortest",
 			oldRange: lsp.Range{
 				Start: lsp.Position{Line: 0, Character: 2},
 				End:   lsp.Position{Line: 0, Character: 3},
 			},
 		},
-		&RefResolution{
+		{
 			ticket: "medium",
 			oldRange: lsp.Range{
 				Start: lsp.Position{Line: 0, Character: 2},

--- a/kythe/go/languageserver/languageserver_test.go
+++ b/kythe/go/languageserver/languageserver_test.go
@@ -87,7 +87,7 @@ func TestReferences(t *testing.T) {
 				resp: xpb.DecorationsReply{
 					SourceText: []byte(sourceText),
 					DefinitionLocations: map[string]*xpb.Anchor{
-						"kythe://corpus?path=file.txt#def": &xpb.Anchor{
+						"kythe://corpus?path=file.txt#def": {
 							Ticket: "kythe://corpus?path=file.txt#def",
 							Parent: "kythe://corpus?path=file.txt",
 							Span: &cpb.Span{
@@ -196,7 +196,7 @@ func TestReferences(t *testing.T) {
 		t.Errorf("Unexpected error finding references: %v", err)
 	}
 
-	expected := []lsp.Location{lsp.Location{
+	expected := []lsp.Location{{
 		URI: "file:///root/dir/file.txt",
 		Range: lsp.Range{
 			Start: lsp.Position{Line: 6, Character: 0},

--- a/kythe/go/languageserver/pathmap/mapper_test.go
+++ b/kythe/go/languageserver/pathmap/mapper_test.go
@@ -34,38 +34,38 @@ type testcase struct {
 }
 
 var cases = map[string]testcase{
-	"": testcase{
+	"": {
 		successes{
 			{"", values{}},
 		},
 		failures{"fail"},
 	},
-	"hello": testcase{
+	"hello": {
 		successes{
 			{"hello", values{}},
 		},
 		failures{"", "notHello"},
 	},
-	":file": testcase{
+	":file": {
 		successes{
 			{"hello", values{"file": "hello"}},
 		},
 		failures{"dir/file"},
 	},
-	"/dir/:file": testcase{
+	"/dir/:file": {
 		successes{
 			{"/dir/test", values{"file": "test"}},
 		},
 		failures{"", "dir/", "dir/test", "/dir/trailing/", "/dir/too/long"},
 	},
-	"/dir/:files*": testcase{
+	"/dir/:files*": {
 		successes{
 			{"/dir/test", values{"files": "test"}},
 			{"/dir/test/nested", values{"files": "test/nested"}},
 		},
 		failures{"/dir/test/", "/dir/"},
 	},
-	"/dir/:splat*/sep/:file": testcase{
+	"/dir/:splat*/sep/:file": {
 		successes{
 			{"/dir/deeply/nested/sep/img.png", values{"splat": "deeply/nested", "file": "img.png"}},
 		},

--- a/kythe/go/services/cli/commands_xrefs.go
+++ b/kythe/go/services/cli/commands_xrefs.go
@@ -70,8 +70,8 @@ func (c xrefsCommand) Run(ctx context.Context, flag *flag.FlagSet, api API) erro
 		PageSize:  int32(c.pageSize),
 		Snippets:  xpb.SnippetsKind_DEFAULT,
 
-		AnchorText:             c.anchorText,
-		NodeDefinitions:        c.nodeDefinitions,
+		AnchorText:      c.anchorText,
+		NodeDefinitions: c.nodeDefinitions,
 	}
 	if c.relatedNodes {
 		req.Filter = []string{facts.NodeKind, facts.Subkind}

--- a/kythe/go/services/link/link_test.go
+++ b/kythe/go/services/link/link_test.go
@@ -129,7 +129,7 @@ func TestResolve(t *testing.T) {
 				},
 				xrefs: &xpb.CrossReferencesReply{
 					CrossReferences: map[string]*xpb.CrossReferencesReply_CrossReferenceSet{
-						"kythe://test?lang=qq#X": &xpb.CrossReferencesReply_CrossReferenceSet{
+						"kythe://test?lang=qq#X": {
 							Ticket: "kythe://test?lang=qq#X",
 							Definition: []*xpb.CrossReferencesReply_RelatedAnchor{{
 								Anchor: &xpb.Anchor{
@@ -174,7 +174,7 @@ func TestResolve(t *testing.T) {
 				},
 				xrefs: &xpb.CrossReferencesReply{
 					CrossReferences: map[string]*xpb.CrossReferencesReply_CrossReferenceSet{
-						"kythe://test?lang=qq#X": &xpb.CrossReferencesReply_CrossReferenceSet{
+						"kythe://test?lang=qq#X": {
 							Ticket: "kythe://test?lang=qq#X",
 							Reference: []*xpb.CrossReferencesReply_RelatedAnchor{{
 								Anchor: new(xpb.Anchor),


### PR DESCRIPTION
No functional changes, only some semantics-preserving cleanup.