### PR TITLE
pack2kzip: Be a little bit less concurrent.

### DIFF
--- a/kythe/go/platform/tools/pack2kzip/BUILD
+++ b/kythe/go/platform/tools/pack2kzip/BUILD
@@ -13,5 +13,6 @@ go_binary(
         "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )


### PR DESCRIPTION
When copying large packs, the file copying stage can exhaust available threads.
Add a throttle to keep that from happening.