### PR TITLE
Fix generic class member JVM names.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -362,8 +362,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       JavaNode implNode = scan(implClass, ctx);
       if (implNode == null) {
         statistics.incrementCounter("warning-missing-implements-node");
-        logger.atWarning().log(
-            "Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
+        logger
+            .atWarning()
+            .log("Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
         continue;
       }
       entrySets.emitEdge(classNode, EdgeKind.EXTENDS, implNode.getVName());
@@ -400,8 +401,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
       JavaNode typeNode = n.getType();
       if (typeNode == null) {
-        logger.atWarning().log(
-            "Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
+        logger
+            .atWarning()
+            .log("Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
         wildcards.addAll(n.childWildcards);
         continue;
       }
@@ -431,7 +433,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     // Emit corresponding JVM node
     if (jvmGraph != null) {
       JvmGraph.Type.MethodType methodJvmType = toMethodJvmType(methodDef.type.asMethodType());
-      ReferenceType parentClass = JvmGraph.Type.referenceType(owner.getTree().type.toString());
+      ReferenceType parentClass = JvmGraph.Type.referenceType(owner.getTree().type.tsym.toString());
       String methodName = methodDef.name.toString();
       VName jvmNode = jvmGraph.emitMethodNode(parentClass, methodName, methodJvmType);
       entrySets.emitEdge(methodNode, EdgeKind.GENERATES, jvmNode);
@@ -567,7 +569,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (jvmGraph != null && varDef.sym.getKind().isField()) {
       VName jvmNode =
           jvmGraph.emitFieldNode(
-              JvmGraph.Type.referenceType(owner.getTree().type.toString()), varDef.name.toString());
+              JvmGraph.Type.referenceType(owner.getTree().type.tsym.toString()),
+              varDef.name.toString());
       entrySets.emitEdge(varNode, EdgeKind.GENERATES, jvmNode);
     }
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -20,6 +20,23 @@ public class Jvm {
   //- Param1Java generates Param1Jvm
   public static void func(int intParam, Object objectParam) {}
 
+  //- @Generic defines/binding GenericAbs
+  //- GenericAbs.node/kind abs
+  //- GenericClass childof GenericAbs
+  //- GenericClass.node/kind record
+  //- GenericClass generates GenericJvm
+  public static class Generic<T> {
+    //- @tfield defines/binding TFieldJava
+    //- TFieldJava.node/kind variable
+    //- TFieldJava generates TFieldJvm
+    private T tfield;
+
+    //- @tmethod defines/binding TMethodJava
+    //- TMethodJava.node/kind function
+    //- TMethodJava generates TMethodJvm
+    private void tmethod(T targ) {}
+  }
+
   //- @nope defines/binding NopeJava
   //- NopeJava generates NopeJvm
   public static <T> T nope() {

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
@@ -16,6 +16,10 @@
 //- Param0Jvm.subkind local/parameter
 //- Param1Jvm.subkind local/parameter
 
+//- GenericJvm=vname("pkg.Jvm.Generic", "", "", "", "jvm").node/kind record
+//- TFieldJvm=vname("pkg.Jvm.Generic.tfield", "", "", "", "jvm").node/kind variable
+//- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Object;)V", "", "", "", "jvm").node/kind function
+
 //- NopeJvm=vname("pkg.Jvm.nope()Ljava/lang/Object;", "", "", "", "jvm").node/kind function
 
 //- GJvm=vname("pkg.Jvm.g([IZBCDFIJS)V", "", "", "", "jvm").node/kind function


### PR DESCRIPTION
Previously, the Java indexer would emit a "generated" JVM node with a signature like `foo.bar.Generic<T>.member` while the JVM indexer would emit the same node with the signature `foo.bar.Generic.member`.  

This commit fixes this by modifying the Java indexer to emit the unadorned name that the JVM indexer emits.

This seems like the right direction to change, because generics are entirely a language feature, and don't exist at the JVM level.  Also, the Java indexer already emits the unadorned name for the class itself. It was just the members that were mismatched.
