### PR TITLE
Represent type params by their erasure in JVM names.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -1240,7 +1240,12 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       case METHOD:
         return toMethodJvmType(type.asMethodType());
       case TYPEVAR:
-        return JvmGraph.Type.referenceType("java.lang.Object");
+        Type boundType = type.getUpperBound();
+        Type erasure =
+            (boundType instanceof Type.IntersectionClassType)
+                ? ((Type.IntersectionClassType) boundType).getComponents().get(0)
+                : boundType;
+        return JvmGraph.Type.referenceType(erasure.toString());
 
       case BOOLEAN:
         return JvmGraph.Type.booleanType();

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -1,5 +1,7 @@
 package pkg;
 
+import java.util.Formattable;
+
 //- @Jvm defines/binding ClassJava
 //- ClassJava generates ClassJvm
 public class Jvm {
@@ -25,7 +27,7 @@ public class Jvm {
   //- GenericClass childof GenericAbs
   //- GenericClass.node/kind record
   //- GenericClass generates GenericJvm
-  public static class Generic<T> {
+  public static class Generic<T extends Integer> {
     //- @tfield defines/binding TFieldJava
     //- TFieldJava.node/kind variable
     //- TFieldJava generates TFieldJvm
@@ -35,6 +37,18 @@ public class Jvm {
     //- TMethodJava.node/kind function
     //- TMethodJava generates TMethodJvm
     private void tmethod(T targ) {}
+  }
+
+  //- @MultipleBoundGeneric defines/binding MBGenericAbs
+  //- MBGenericAbs.node/kind abs
+  //- MBGenericClass childof MBGenericAbs
+  //- MBGenericClass.node/kind record
+  //- MBGenericClass generates MBGenericJvm
+  public static class MultipleBoundGeneric<T extends Integer & Formattable> {
+    //- @mbtmethod defines/binding MBTMethodJava
+    //- MBTMethodJava.node/kind function
+    //- MBTMethodJava generates MBTMethodJvm
+    private void mbtmethod(T targ) {}
   }
 
   //- @nope defines/binding NopeJava

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
@@ -18,7 +18,10 @@
 
 //- GenericJvm=vname("pkg.Jvm.Generic", "", "", "", "jvm").node/kind record
 //- TFieldJvm=vname("pkg.Jvm.Generic.tfield", "", "", "", "jvm").node/kind variable
-//- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Object;)V", "", "", "", "jvm").node/kind function
+//- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
+
+//- MBGenericJvm=vname("pkg.Jvm.MultipleBoundGeneric", "", "", "", "jvm").node/kind record
+//- MBTMethodJvm=vname("pkg.Jvm.MultipleBoundGeneric.mbtmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
 
 //- NopeJvm=vname("pkg.Jvm.nope()Ljava/lang/Object;", "", "", "", "jvm").node/kind function
 


### PR DESCRIPTION
Previously we hard-coded j.l.Object in the source indexer, which did not match what the binary indexer emits.

Tests that this works for both simple and multiple-bound generics (in the latter case, the first bound is the erasure, by definition).