### PR TITLE
Rework interface on extractor to not hard code git clone.

### DIFF
--- a/kythe/go/extractors/config/extractor.go
+++ b/kythe/go/extractors/config/extractor.go
@@ -43,7 +43,7 @@ type Repo struct {
 	ConfigPath string
 }
 
-// GitCopier creates a Repo.Clone that fetches repos via git commandline.
+// GitCopier returns a function that clones a repository via git command line.
 func GitCopier(repoURI string) func(ctx context.Context, outputDir string) error {
 	return func(ctx context.Context, outputDir string) error {
 		// TODO(danielmoy): strongly consider go-git instead of os.exec

--- a/kythe/go/extractors/config/smoke/smoke.go
+++ b/kythe/go/extractors/config/smoke/smoke.go
@@ -45,7 +45,7 @@ type Fetcher func(ctx context.Context, repo, outputPath string) error
 
 // GitFetch fetches repos using git commandline.
 func GitFetch(ctx context.Context, repo, outputPath string) error {
-	return config.GitCopier(ctx, repo)(outputPath)
+	return config.GitCopier(repo)(ctx, outputPath)
 }
 
 // Indexer takes .kindex files in a given inputDir, indexes them, and deposits
@@ -200,7 +200,7 @@ func (h Harness) filenamesFromExtraction(ctx context.Context, repoURI string) (m
 	defer os.RemoveAll(tmpOutDir)
 
 	if err := h.extractor()(ctx, config.Repo{
-		Copier:     config.GitCopier(ctx, repoURI),
+		Clone:      config.GitCopier(repoURI),
 		OutputPath: tmpOutDir,
 		ConfigPath: h.ConfigPath,
 	}); err != nil {

--- a/kythe/go/extractors/config/smoke/smoke.go
+++ b/kythe/go/extractors/config/smoke/smoke.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -42,12 +41,11 @@ import (
 type Tester func(ctx context.Context, repo string) (Result, error)
 
 // Fetcher is fetches a given repo and writes it to an output directory.
-type Fetcher func(ctx context.Context, repo config.Repo) error
+type Fetcher func(ctx context.Context, repo, outputPath string) error
 
 // GitFetch fetches repos using git commandline.
-func GitFetch(ctx context.Context, repo config.Repo) error {
-	// TODO(danielmoy): strongly consider go-git instead of os.exec
-	return exec.CommandContext(ctx, "git", "clone", repo.URI, repo.OutputPath).Run()
+func GitFetch(ctx context.Context, repo, outputPath string) error {
+	return config.GitCopier(ctx, repo)(outputPath)
 }
 
 // Indexer takes .kindex files in a given inputDir, indexes them, and deposits
@@ -172,10 +170,7 @@ func (h Harness) filenamesFromRepo(ctx context.Context, repoURI string) (map[str
 	}
 	defer os.RemoveAll(repoDir)
 
-	if err = h.fetcher()(ctx, config.Repo{
-		URI:        repoURI,
-		OutputPath: repoDir,
-	}); err != nil {
+	if err = h.fetcher()(ctx, repoURI, repoDir); err != nil {
 		return nil, err
 	}
 
@@ -205,7 +200,7 @@ func (h Harness) filenamesFromExtraction(ctx context.Context, repoURI string) (m
 	defer os.RemoveAll(tmpOutDir)
 
 	if err := h.extractor()(ctx, config.Repo{
-		URI:        repoURI,
+		Copier:     config.GitCopier(ctx, repoURI),
 		OutputPath: tmpOutDir,
 		ConfigPath: h.ConfigPath,
 	}); err != nil {

--- a/kythe/go/extractors/config/smoke/smoke_test.go
+++ b/kythe/go/extractors/config/smoke/smoke_test.go
@@ -93,9 +93,9 @@ func writeSingleKindex(path string, unit *kindex.Compilation) error {
 	return f.Close()
 }
 
-func (e testExtractor) Fetch(ctx context.Context, repo config.Repo) error {
+func (e testExtractor) Fetch(ctx context.Context, _, outputPath string) error {
 	for k, v := range e.repoFiles {
-		if err := ioutil.WriteFile(filepath.Join(repo.OutputPath, k), v, 0444); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outputPath, k), v, 0444); err != nil {
 			return err
 		}
 	}

--- a/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
+++ b/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
@@ -35,8 +35,8 @@ import (
 )
 
 var (
-	repoURI    = flag.String("remote_repo", "", "URI of the repository containing the project to be extracted")
-	repoPath   = flag.String("local_repo", "", "Existing local copy of the repository containing the project to be extracted")
+	repoURI    = flag.String("remote", "", "URI of the repository containing the project to be extracted")
+	repoPath   = flag.String("local", "", "Existing local directory copy of the repository containing the project to be extracted")
 	outputPath = flag.String("output", "", "Path for output kindex file")
 	configPath = flag.String("config", "", "Path for the JSON extraction configuration file")
 	timeout    = flag.Duration("timeout", 2*time.Minute, "Timeout for extraction")
@@ -44,16 +44,23 @@ var (
 
 func init() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, `Usage: %s -remote_repo <repo_uri> -output <path> -config [config_file_path]
+		fmt.Fprintf(os.Stderr, `Usage: %s -remote <repo_uri> -output <path> -config [config_file_path]
 
 This tool extracts compilation records from a repository utilizing a JSON
 extraction configuration encoding a kythe.proto.ExtractionConfiguration.
-This configuration is specified either via the -config flag, or else within
+
+The originating repo to extract is specified either by -remote <repo_uri> and
+done via a git clone, or -local <repo_path> and simply copying the repo over.
+Specifying both -remote and -local is invalid input.
+
+The configuration is specified either via the -config flag, or else within
 a configuration file located at the root of the repository named:
 ".kythe-extraction-config". It makes a local clone of the specified repository
 and then uses the config to generate a customized extraction Docker image.
+
 Finally it executes the extraction by running the extraction image, the output
 of which is a kindex file as defined here:  http://kythe.io/docs/kythe-index-pack.html
+
 This binary requires both Git and Docker to be on the $PATH during execution.
 
 Options:
@@ -70,11 +77,11 @@ func verifyFlags() {
 	hasError := false
 	if *repoURI == "" && *repoPath == "" {
 		hasError = true
-		log.Println("You must provide a non-empty -remote_repo or -local_repo")
+		log.Println("You must provide a non-empty -remote or -local")
 	}
 	if *repoURI != "" && *repoPath != "" {
 		hasError = true
-		log.Println("You must specify only one of -remote_repo or -local_repo, not both")
+		log.Println("You must specify only one of -remote or -local, not both")
 	}
 
 	if *outputPath == "" {
@@ -101,10 +108,10 @@ func main() {
 		ConfigPath: *configPath,
 	}
 	if *repoURI != "" {
-		repo.Copier = config.GitCopier(ctx, *repoURI)
+		repo.Clone = config.GitCopier(*repoURI)
 	} else if *repoPath != "" {
 		// TODO(danielmoy): implement local copy
-		log.Fatal("-local_repo not yet supported, sorry.")
+		log.Fatal("-local not yet supported, sorry.")
 	} else {
 		// I know I checked it earlier but I don't trust myself to not
 		// break this in the future.

--- a/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
+++ b/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
@@ -19,7 +19,7 @@
 // $PATH during execution.
 //
 // Usage:
-//   extractrepo -repo <repo_uri> -output <output_file_path> -config [config_file_path]
+//   extractrepo -repo <repo-url> -output <output-file-path> -config [config-file-path]
 package main
 
 import (
@@ -49,8 +49,8 @@ func init() {
 This tool extracts compilation records from a repository utilizing a JSON
 extraction configuration encoding a kythe.proto.ExtractionConfiguration.
 
-The originating repo to extract is specified either by -remote <repo_uri> and
-done via a git clone, or -local <repo_path> and simply copying the repo over.
+The originating repo to extract is specified either by -remote <repo-url> and
+done via a git clone, or -local <repo-path> and simply copying the repo over.
 Specifying both -remote and -local is invalid input.
 
 The configuration is specified either via the -config flag, or else within


### PR DESCRIPTION
Opens up future possibility to do a simple copy from local disk if we already have the repo living somewhere.

I'm not super sold on the exact interface here, but this brings us one step closer to nixing a lot of the copying work.

Slight added benefit: consolidating the git clone logic in extractor instead of replicating it in smoke harness as well.

