### PR TITLE
Push JVM reference type normalization from #118 into core JvmGraph

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -362,9 +362,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       JavaNode implNode = scan(implClass, ctx);
       if (implNode == null) {
         statistics.incrementCounter("warning-missing-implements-node");
-        logger
-            .atWarning()
-            .log("Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
+        logger.atWarning().log(
+            "Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
         continue;
       }
       entrySets.emitEdge(classNode, EdgeKind.EXTENDS, implNode.getVName());
@@ -401,9 +400,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
       JavaNode typeNode = n.getType();
       if (typeNode == null) {
-        logger
-            .atWarning()
-            .log("Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
+        logger.atWarning().log(
+            "Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
         wildcards.addAll(n.childWildcards);
         continue;
       }
@@ -433,7 +431,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     // Emit corresponding JVM node
     if (jvmGraph != null) {
       JvmGraph.Type.MethodType methodJvmType = toMethodJvmType(methodDef.type.asMethodType());
-      ReferenceType parentClass = JvmGraph.Type.referenceType(owner.getTree().type.tsym.toString());
+      ReferenceType parentClass = JvmGraph.Type.referenceType(owner.getTree().type.toString());
       String methodName = methodDef.name.toString();
       VName jvmNode = jvmGraph.emitMethodNode(parentClass, methodName, methodJvmType);
       entrySets.emitEdge(methodNode, EdgeKind.GENERATES, jvmNode);
@@ -569,8 +567,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (jvmGraph != null && varDef.sym.getKind().isField()) {
       VName jvmNode =
           jvmGraph.emitFieldNode(
-              JvmGraph.Type.referenceType(owner.getTree().type.tsym.toString()),
-              varDef.name.toString());
+              JvmGraph.Type.referenceType(owner.getTree().type.toString()), varDef.name.toString());
       entrySets.emitEdge(varNode, EdgeKind.GENERATES, jvmNode);
     }
 

--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
@@ -297,7 +297,9 @@ public class JvmGraph {
     /** Returns a new JVM class/enum/interface type descriptor. */
     public static ReferenceType referenceType(String qualifiedName) {
       Preconditions.checkNotNull(qualifiedName);
-      return new ReferenceType(qualifiedName.replace("$", "."));
+      // Normalized qualified name (e.g. java.util.Map$Entry<K, V> -> java.util.Map.Entry)
+      String normalized = qualifiedName.replace("$", ".").replaceAll("<[^\\]]+>", "");
+      return new ReferenceType(normalized);
     }
 
     /** Returns a new JVM method type descriptor. */


### PR DESCRIPTION
This ensures all JvmGraph clients work equivalently.