### PR TITLE
disksort: properly flush snappy.Writer

### DIFF
--- a/kythe/go/serving/pipeline/pipeline.go
+++ b/kythe/go/serving/pipeline/pipeline.go
@@ -68,10 +68,6 @@ type Options struct {
 	// MaxShardSize is the maximum number of elements to keep in-memory before
 	// flushing an intermediary data shard to disk.
 	MaxShardSize int
-
-	// IOBufferSize is the size of the reading/writing buffers for the temporary
-	// file shards.
-	IOBufferSize int
 }
 
 func (o *Options) diskSorter(l sortutil.Lesser, m disksort.Marshaler) (disksort.Interface, error) {
@@ -80,7 +76,6 @@ func (o *Options) diskSorter(l sortutil.Lesser, m disksort.Marshaler) (disksort.
 		Marshaler:      m,
 		MaxInMemory:    o.MaxShardSize,
 		CompressShards: o.CompressShards,
-		IOBufferSize:   o.IOBufferSize,
 	})
 }
 

--- a/kythe/go/serving/tools/write_tables/BUILD
+++ b/kythe/go/serving/tools/write_tables/BUILD
@@ -14,7 +14,6 @@ go_binary(
         "//kythe/go/storage/gsutil",
         "//kythe/go/storage/leveldb",
         "//kythe/go/storage/stream",
-        "//kythe/go/util/datasize",
         "//kythe/go/util/flagutil",
         "//kythe/go/util/profile",
         "//kythe/proto:pipeline_go_proto",

--- a/kythe/go/serving/tools/write_tables/write_tables.go
+++ b/kythe/go/serving/tools/write_tables/write_tables.go
@@ -32,7 +32,6 @@ import (
 	"kythe.io/kythe/go/storage/gsutil"
 	"kythe.io/kythe/go/storage/leveldb"
 	"kythe.io/kythe/go/storage/stream"
-	"kythe.io/kythe/go/util/datasize"
 	"kythe.io/kythe/go/util/flagutil"
 	"kythe.io/kythe/go/util/profile"
 
@@ -57,8 +56,6 @@ var (
 		"Determines whether intermediate data written to disk should be compressed.")
 	maxShardSize = flag.Int("max_shard_size", 32000,
 		"Maximum number of elements (edges, decoration fragments, etc.) to keep in-memory before flushing an intermediary data shard to disk.")
-	shardIOBufferSize = datasize.Flag("shard_io_buffer", "16KiB",
-		"Size of the reading/writing buffers for the intermediary data shards.")
 
 	verbose = flag.Bool("verbose", false, "Whether to emit extra, and possibly excessive, log messages")
 
@@ -121,7 +118,6 @@ func main() {
 		MaxPageSize:    *maxPageSize,
 		CompressShards: *compressShards,
 		MaxShardSize:   *maxShardSize,
-		IOBufferSize:   int(shardIOBufferSize.Bytes()),
 	}); err != nil {
 		log.Fatal("FATAL ERROR: ", err)
 	}


### PR DESCRIPTION
Since the Snappy Reader/Writers have a static buffer size, remove the IOBufferSize option and stick with what Snappy uses as a buffer size.