### PR TITLE
kzip: Allow propagating Close.

### DIFF
--- a/kythe/go/extractors/cmd/gotool/gotool.go
+++ b/kythe/go/extractors/cmd/gotool/gotool.go
@@ -160,7 +160,7 @@ func writeToKZip(ctx context.Context, path string) packageWriter {
 	if err != nil {
 		log.Fatalf("Unable to create output file: %v", err)
 	}
-	w, err := kzip.NewWriter(f)
+	w, err := kzip.NewWriteCloser(f)
 	if err != nil {
 		log.Fatalf("Unable to create kzip writer: %v", err)
 	}


### PR DESCRIPTION
Add a new constructor NewWriteCloser, which behaves as the normal constructor
save that it takes an io.WriteCloser instead of an io.Writer, and arranges that
when closing the kzip writer, the underlying io.WriteCloser will also be closed.

This simplifies use of the library with files that must otherwise be closed
explicitly. Tests are included to verify that error propagation does the
sensible thing.