### PR TITLE
go_indexer: Add the ability to read kzip inputs.

### DIFF
--- a/kythe/go/indexer/cmd/go_indexer/BUILD
+++ b/kythe/go/indexer/cmd/go_indexer/BUILD
@@ -10,6 +10,7 @@ go_binary(
         "//kythe/go/platform/delimited",
         "//kythe/go/platform/indexpack",
         "//kythe/go/platform/kindex",
+        "//kythe/go/platform/kzip",
         "//kythe/go/platform/vfs",
         "//kythe/go/util/metadata",
         "//kythe/proto:analysis_go_proto",

--- a/kythe/go/indexer/cmd/go_indexer/go_indexer.go
+++ b/kythe/go/indexer/cmd/go_indexer/go_indexer.go
@@ -212,7 +212,7 @@ func openPack(ctx context.Context, path string) (*indexpack.Archive, error) {
 type kzipFetcher struct{ r *kzip.Reader }
 
 // Fetch implements the analysis.Fetcher interface. Only the digest is used in
-// this implementation,, the path is ignored.
+// this implementation, the path is ignored.
 func (k kzipFetcher) Fetch(_, digest string) ([]byte, error) {
 	return k.r.ReadAll(digest)
 }


### PR DESCRIPTION
As part of the ongoing work to replace .kindex files and indexpacks, add the
ability to add .kzip input to the Go indexer. For now, the other formats are
still supported.