### PR TITLE
extract_kindex: Add support for writing kzip files as output.

### DIFF
--- a/kythe/go/extractors/bazel/utils.go
+++ b/kythe/go/extractors/bazel/utils.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"kythe.io/kythe/go/platform/kzip"
 	"kythe.io/kythe/go/util/ptypes"
 	"kythe.io/kythe/go/util/vnameutil"
 
@@ -54,6 +55,21 @@ func Write(w io.WriterTo, path string) error {
 	}
 	log.Printf("Finished writing output [%v elapsed]", time.Since(start))
 	return nil
+}
+
+// NewKZIP creates a kzip writer at path, replacing any existing file at that
+// location. Closing the returned writer also closes the underlying file.
+func NewKZIP(path string) (*kzip.Writer, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("creating output file: %v", err)
+	}
+	w, err := kzip.NewWriteCloser(f)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+	return w, nil
 }
 
 // LoadAction loads and parses a wire-format ExtraActionInfo message from the

--- a/kythe/go/extractors/cmd/bazel/extract_kindex/extract_kindex.go
+++ b/kythe/go/extractors/cmd/bazel/extract_kindex/extract_kindex.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"path/filepath"
 	"time"
 
 	"kythe.io/kythe/go/extractors/bazel"
@@ -50,17 +51,36 @@ func main() {
 		log.Fatalf("Invalid config settings: %v", err)
 	}
 
+	ctx := context.Background()
 	start := time.Now()
 	ai, err := bazel.SpawnAction(info)
 	if err != nil {
 		log.Fatalf("Invalid extra action: %v", err)
 	}
-	cu, err := config.Extract(context.Background(), ai)
-	if err != nil {
-		log.Fatalf("Extraction failed: %v", err)
+	switch ext := filepath.Ext(*outputPath); ext {
+	case ".kindex":
+		// Write a .kindex file.
+		// TODO(fromberger): Remove this once everything is using kzip.
+		cu, err := config.Extract(context.Background(), ai)
+		if err != nil {
+			log.Fatalf("Extraction failed: %v", err)
+		}
+		if err := bazel.Write(cu, *outputPath); err != nil {
+			log.Fatalf("Writing index output: %v", err)
+		}
+
+	case ".kzip":
+		// Write a .kzip file.
+		w, err := bazel.NewKZIP(*outputPath)
+		if err != nil {
+			log.Fatalf("Creating kzip writer: %v", err)
+		}
+		if _, err := config.ExtractToFile(ctx, ai, w); err != nil {
+			log.Fatalf("Extraction failed: %v", err)
+		}
+
+	default:
+		log.Fatalf("Unknown output extension %q", ext)
 	}
 	log.Printf("Finished extracting [%v elapsed]", time.Since(start))
-	if err := bazel.Write(cu, *outputPath); err != nil {
-		log.Fatalf("Writing index: %v", err)
-	}
 }


### PR DESCRIPTION
As part of the migration from kindex files, update the extract_kindex tool to
support writing kzip output. We will eventually want to rename the binary too,
but that can be a separate step; for now, it continues to support kindex also.