### PR TITLE
Fix the JVM signatures of methods with generic parameters.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -361,9 +361,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       JavaNode implNode = scan(implClass, ctx);
       if (implNode == null) {
         statistics.incrementCounter("warning-missing-implements-node");
-        logger
-            .atWarning()
-            .log("Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
+        logger.atWarning().log(
+            "Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
         continue;
       }
       entrySets.emitEdge(classNode, EdgeKind.EXTENDS, implNode.getVName());
@@ -400,9 +399,8 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
       JavaNode typeNode = n.getType();
       if (typeNode == null) {
-        logger
-            .atWarning()
-            .log("Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
+        logger.atWarning().log(
+            "Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
         wildcards.addAll(n.childWildcards);
         continue;
       }

--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -280,8 +280,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (nestingKind != NestingKind.LOCAL && nestingKind != NestingKind.ANONYMOUS) {
       if (jvmGraph != null) {
         // Emit corresponding JVM node
-        JvmGraph.Type.ReferenceType referenceType =
-            JvmGraph.Type.referenceType(classDef.sym.fullname.toString());
+        JvmGraph.Type.ReferenceType referenceType = referenceType(classDef.sym.type);
         VName jvmNode = jvmGraph.emitClassNode(referenceType);
         entrySets.emitEdge(classNode, EdgeKind.GENERATES, jvmNode);
       } else {
@@ -362,8 +361,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       JavaNode implNode = scan(implClass, ctx);
       if (implNode == null) {
         statistics.incrementCounter("warning-missing-implements-node");
-        logger.atWarning().log(
-            "Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
+        logger
+            .atWarning()
+            .log("Missing 'implements' node for %s: %s", implClass.getClass(), implClass);
         continue;
       }
       entrySets.emitEdge(classNode, EdgeKind.EXTENDS, implNode.getVName());
@@ -400,8 +400,9 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
 
       JavaNode typeNode = n.getType();
       if (typeNode == null) {
-        logger.atWarning().log(
-            "Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
+        logger
+            .atWarning()
+            .log("Missing parameter type (method: %s; parameter: %s)", methodDef.getName(), param);
         wildcards.addAll(n.childWildcards);
         continue;
       }
@@ -431,7 +432,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     // Emit corresponding JVM node
     if (jvmGraph != null) {
       JvmGraph.Type.MethodType methodJvmType = toMethodJvmType(methodDef.type.asMethodType());
-      ReferenceType parentClass = JvmGraph.Type.referenceType(owner.getTree().type.toString());
+      ReferenceType parentClass = referenceType(owner.getTree().type);
       String methodName = methodDef.name.toString();
       VName jvmNode = jvmGraph.emitMethodNode(parentClass, methodName, methodJvmType);
       entrySets.emitEdge(methodNode, EdgeKind.GENERATES, jvmNode);
@@ -566,8 +567,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     // Emit corresponding JVM node
     if (jvmGraph != null && varDef.sym.getKind().isField()) {
       VName jvmNode =
-          jvmGraph.emitFieldNode(
-              JvmGraph.Type.referenceType(owner.getTree().type.toString()), varDef.name.toString());
+          jvmGraph.emitFieldNode(referenceType(owner.getTree().type), varDef.name.toString());
       entrySets.emitEdge(varNode, EdgeKind.GENERATES, jvmNode);
     }
 
@@ -1233,7 +1233,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       case ARRAY:
         return JvmGraph.Type.arrayType(toJvmType(((Type.ArrayType) type).getComponentType()));
       case CLASS:
-        return JvmGraph.Type.referenceType(type.toString());
+        return referenceType(type);
       case METHOD:
         return toMethodJvmType(type.asMethodType());
       case TYPEVAR:
@@ -1264,6 +1264,13 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       default:
         throw new IllegalStateException("unhandled Java Type: " + type.getTag());
     }
+  }
+
+  /** Returns a new JVM class/enum/interface type descriptor to the specified source type. */
+  private static ReferenceType referenceType(Type referent) {
+    Preconditions.checkNotNull(referent);
+    String qualifiedName = referent.tsym.toString();
+    return JvmGraph.Type.referenceType(qualifiedName);
   }
 
   private static JvmGraph.VoidableType toJvmReturnType(Type type) {

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -1,6 +1,7 @@
 package pkg;
 
 import java.util.Formattable;
+import java.util.List;
 
 //- @Jvm defines/binding ClassJava
 //- ClassJava generates ClassJvm
@@ -37,6 +38,18 @@ public class Jvm {
     //- TMethodJava.node/kind function
     //- TMethodJava generates TMethodJvm
     private void tmethod(T targ) {}
+
+    //- @tlistmethod defines/binding TListMethodJava
+    //- TListMethodJava.node/kind function
+    //- TListMethodJava generates TListMethodJvm
+    private void tlistmethod(List<T> targ) {}
+
+    //- @tlistretmethod defines/binding TListRetMethodJava
+    //- TListRetMethodJava.node/kind function
+    //- TListRetMethodJava generates TListRetMethodJvm
+    private List<T> tlistretmethod() {
+      return null;
+    }
   }
 
   //- @MultipleBoundGeneric defines/binding MBGenericAbs

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
@@ -19,6 +19,8 @@
 //- GenericJvm=vname("pkg.Jvm.Generic", "", "", "", "jvm").node/kind record
 //- TFieldJvm=vname("pkg.Jvm.Generic.tfield", "", "", "", "jvm").node/kind variable
 //- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
+//- TListMethodJvm=vname("pkg.Jvm.Generic.tlistmethod(Ljava/util/List;)V", "", "", "", "jvm").node/kind function
+//- TListRetMethodJvm=vname("pkg.Jvm.Generic.tlistretmethod()Ljava/util/List;", "", "", "", "jvm").node/kind function
 
 //- MBGenericJvm=vname("pkg.Jvm.MultipleBoundGeneric", "", "", "", "jvm").node/kind record
 //- MBTMethodJvm=vname("pkg.Jvm.MultipleBoundGeneric.mbtmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function


### PR DESCRIPTION
The JVM indexer emits, e.g., `pkg.Jvm.Generic.tlistmethod(Ljava/util/List;)V`, 
while prior to this change the source indexer emitted, e.g., `pkg.Jvm.Generic.tlistmethod(Ljava/util/List<T>;)V`.

This change creates a `referenceType(Type referent)` helper method in `KytheTreeScanner`, instead of having to remember how to get the underlying `tsym` everywhere.