### PR TITLE
Obtain JVM (aka "external") names in a principled way.

### DIFF
--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -1,6 +1,7 @@
 package pkg;
 
 import java.util.Formattable;
+import java.util.List;
 
 //- @Jvm defines/binding ClassJava
 //- ClassJava generates ClassJvm
@@ -10,9 +11,21 @@ public class Jvm {
   //- IntFieldJava generates IntFieldJvm
   int intField;
 
+  //- @Nested defines/binding NestedJava
+  //- NestedJava generates NestedJvm
+  public static class Nested {
+    //- @Nested defines/binding NestedCtorJava
+    //- NestedCtorJava generates NestedCtorJvm
+    public Nested() {}
+  }
+
   //- @Inner defines/binding InnerJava
   //- InnerJava generates InnerJvm
-  public static class Inner {}
+  public class Inner {
+    //- @Inner defines/binding InnerCtorJava
+    //- InnerCtorJava generates InnerCtorJvm
+    public Inner() {}
+  }
 
   //- @func defines/binding FuncJava
   //- FuncJava generates FuncJvm
@@ -37,6 +50,18 @@ public class Jvm {
     //- TMethodJava.node/kind function
     //- TMethodJava generates TMethodJvm
     private void tmethod(T targ) {}
+
+    //- @tlistmethod defines/binding TListMethodJava
+    //- TListMethodJava.node/kind function
+    //- TListMethodJava generates TListMethodJvm
+    private void tlistmethod(List<T> targ) {}
+
+    //- @tlistretmethod defines/binding TListRetMethodJava
+    //- TListRetMethodJava.node/kind function
+    //- TListRetMethodJava generates TListRetMethodJvm
+    private List<T> tlistretmethod() {
+      return null;
+    }
   }
 
   //- @MultipleBoundGeneric defines/binding MBGenericAbs

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
@@ -7,8 +7,13 @@
 //- IntFieldJvm=vname("pkg.Jvm.intField", "", "", "", "jvm").node/kind variable
 //- IntFIeldJvm.subkind field
 
+//- NestedJvm=vname("pkg.Jvm.Nested", "", "", "", "jvm").node/kind record
+//- NestedJvm.subkind class
+//- NestedCtorJvm=vname("pkg.Jvm.Nested.<init>()V", "", "", "", "jvm").node/kind function
+
 //- InnerJvm=vname("pkg.Jvm.Inner", "", "", "", "jvm").node/kind record
 //- InnerJvm.subkind class
+//- InnerCtorJvm=vname("pkg.Jvm.Inner.<init>(Lpkg/Jvm;)V", "", "", "", "jvm").node/kind function
 
 //- FuncJvm=vname("pkg.Jvm.func(ILjava/lang/Object;)V", "", "", "", "jvm").node/kind function
 //- Param0Jvm=vname("pkg.Jvm.func(ILjava/lang/Object;)V.param0", "", "", "", "jvm").node/kind variable
@@ -19,6 +24,8 @@
 //- GenericJvm=vname("pkg.Jvm.Generic", "", "", "", "jvm").node/kind record
 //- TFieldJvm=vname("pkg.Jvm.Generic.tfield", "", "", "", "jvm").node/kind variable
 //- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
+//- TListMethodJvm=vname("pkg.Jvm.Generic.tlistmethod(Ljava/util/List;)V", "", "", "", "jvm").node/kind function
+//- TListRetMethodJvm=vname("pkg.Jvm.Generic.tlistretmethod()Ljava/util/List;", "", "", "", "jvm").node/kind function
 
 //- MBGenericJvm=vname("pkg.Jvm.MultipleBoundGeneric", "", "", "", "jvm").node/kind record
 //- MBTMethodJvm=vname("pkg.Jvm.MultipleBoundGeneric.mbtmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function


### PR DESCRIPTION
Instead of hand-crafted logic, this defers to the compiler's own data structures, which do the right thing in multiple cases, such as type erasure, synthetic inner class ctor params, generics in method signatures, etc.

This change adds several test cases.

This supersedes https://github.com/google/kythe/pull/139 and replaces logic previously implemented in https://github.com/google/kythe/pull/120 and https://github.com/google/kythe/pull/118. 