### PR TITLE
Fix JVM names of inner classes.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/KytheTreeScanner.java
@@ -281,8 +281,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (nestingKind != NestingKind.LOCAL && nestingKind != NestingKind.ANONYMOUS) {
       if (jvmGraph != null) {
         // Emit corresponding JVM node
-        JvmGraph.Type.ReferenceType referenceType =
-            JvmGraph.Type.referenceType(classDef.sym.fullname.toString());
+        JvmGraph.Type.ReferenceType referenceType = referenceType(classDef.sym.type);
         VName jvmNode = jvmGraph.emitClassNode(referenceType);
         entrySets.emitEdge(classNode, EdgeKind.GENERATES, jvmNode);
       } else {
@@ -433,8 +432,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (jvmGraph != null) {
       JvmGraph.Type.MethodType methodJvmType =
           toMethodJvmType((Type.MethodType) externalType(methodDef.sym));
-      ReferenceType parentClass =
-          JvmGraph.Type.referenceType(externalType(owner.getTree().type.tsym).toString());
+      ReferenceType parentClass = referenceType(externalType(owner.getTree().type.tsym));
       String methodName = methodDef.name.toString();
       VName jvmNode = jvmGraph.emitMethodNode(parentClass, methodName, methodJvmType);
       entrySets.emitEdge(methodNode, EdgeKind.GENERATES, jvmNode);
@@ -570,8 +568,7 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
     if (jvmGraph != null && varDef.sym.getKind().isField()) {
       VName jvmNode =
           jvmGraph.emitFieldNode(
-              JvmGraph.Type.referenceType(externalType(owner.getTree().type.tsym).toString()),
-              varDef.name.toString());
+              referenceType(externalType(owner.getTree().type.tsym)), varDef.name.toString());
       entrySets.emitEdge(varNode, EdgeKind.GENERATES, jvmNode);
     }
 
@@ -1241,11 +1238,11 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       case ARRAY:
         return JvmGraph.Type.arrayType(toJvmType(((Type.ArrayType) type).getComponentType()));
       case CLASS:
-        return JvmGraph.Type.referenceType(type.toString());
+        return referenceType(type);
       case METHOD:
         return toMethodJvmType(type.asMethodType());
       case TYPEVAR:
-        return JvmGraph.Type.referenceType(type.toString());
+        return referenceType(type);
 
       case BOOLEAN:
         return JvmGraph.Type.booleanType();
@@ -1267,6 +1264,12 @@ public class KytheTreeScanner extends JCTreeScanner<JavaNode, TreeContext> {
       default:
         throw new IllegalStateException("unhandled Java Type: " + type.getTag());
     }
+  }
+
+  /** Returns a new JVM class/enum/interface type descriptor to the specified source type. */
+  private static ReferenceType referenceType(Type referent) {
+    String qualifiedName = referent.tsym.flatName().toString();
+    return JvmGraph.Type.referenceType(qualifiedName);
   }
 
   private static JvmGraph.VoidableType toJvmReturnType(Type type) {

--- a/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/jvm/JvmGraph.java
@@ -297,8 +297,8 @@ public class JvmGraph {
     /** Returns a new JVM class/enum/interface type descriptor. */
     public static ReferenceType referenceType(String qualifiedName) {
       Preconditions.checkNotNull(qualifiedName);
-      // Normalized qualified name (e.g. java.util.Map$Entry<K, V> -> java.util.Map.Entry)
-      String normalized = qualifiedName.replace("$", ".").replaceAll("<[^\\]]+>", "");
+      // Normalized qualified name (e.g. java.util.Map$Entry<K, V> -> java.util.Map$Entry)
+      String normalized = qualifiedName.replaceAll("<[^\\]]+>", "");
       return new ReferenceType(normalized);
     }
 

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/java/testdata/pkg/Jvm.java
@@ -25,7 +25,20 @@ public class Jvm {
     //- @Inner defines/binding InnerCtorJava
     //- InnerCtorJava generates InnerCtorJvm
     public Inner() {}
+
+    //- @InnerInner defines/binding InnerInnerJava
+    //- InnerInnerJava generates InnerInnerJvm
+    public class InnerInner {
+      //- @InnerInner defines/binding InnerInnerCtorJava
+      //- InnerInnerCtorJava generates InnerInnerCtorJvm
+      public InnerInner() {}
+    }
   }
+
+  //- @methodWithInnerParam defines/binding MethodWithInnerParamJava
+  //- MethodWithInnerParamJava.node/kind function
+  //- MethodWithInnerParamJava generates MethodWithInnerParamJvm
+  private void methodWithInnerParam(Inner inner) {}
 
   //- @func defines/binding FuncJava
   //- FuncJava generates FuncJvm

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/JvmGraphTest.java
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/JvmGraphTest.java
@@ -29,7 +29,7 @@ public final class JvmGraphTest extends TestCase {
     assertThat(objectType.toString()).isEqualTo("Ljava/lang/Object;");
     assertThat(Type.referenceType("java/lang/Object")).isEqualTo(objectType);
     assertThat(Type.referenceType("java.util.Map$Entry").toString())
-        .isEqualTo("Ljava/util/Map/Entry;");
+        .isEqualTo("Ljava/util/Map$Entry;");
     assertThat(Type.booleanType().toString()).isEqualTo("Z");
     assertThat(Type.byteType().toString()).isEqualTo("B");
     assertThat(Type.arrayType(objectType).toString()).isEqualTo("[Ljava/lang/Object;");

--- a/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
+++ b/kythe/javatests/com/google/devtools/kythe/analyzers/jvm/testdata/jvm_nodes.kythe_verifier.txt
@@ -7,13 +7,19 @@
 //- IntFieldJvm=vname("pkg.Jvm.intField", "", "", "", "jvm").node/kind variable
 //- IntFIeldJvm.subkind field
 
-//- NestedJvm=vname("pkg.Jvm.Nested", "", "", "", "jvm").node/kind record
+//- NestedJvm=vname("pkg.Jvm$Nested", "", "", "", "jvm").node/kind record
 //- NestedJvm.subkind class
-//- NestedCtorJvm=vname("pkg.Jvm.Nested.<init>()V", "", "", "", "jvm").node/kind function
+//- NestedCtorJvm=vname("pkg.Jvm$Nested.<init>()V", "", "", "", "jvm").node/kind function
 
-//- InnerJvm=vname("pkg.Jvm.Inner", "", "", "", "jvm").node/kind record
+//- InnerJvm=vname("pkg.Jvm$Inner", "", "", "", "jvm").node/kind record
 //- InnerJvm.subkind class
-//- InnerCtorJvm=vname("pkg.Jvm.Inner.<init>(Lpkg/Jvm;)V", "", "", "", "jvm").node/kind function
+//- InnerCtorJvm=vname("pkg.Jvm$Inner.<init>(Lpkg/Jvm;)V", "", "", "", "jvm").node/kind function
+
+//- InnerInnerJvm=vname("pkg.Jvm$Inner$InnerInner", "", "", "", "jvm").node/kind record
+//- InnerInnerJvm.subkind class
+//- InnerInnerCtorJvm=vname("pkg.Jvm$Inner$InnerInner.<init>(Lpkg/Jvm$Inner;)V", "", "", "", "jvm").node/kind function
+
+//- MethodWithInnerParamJvm=vname("pkg.Jvm.methodWithInnerParam(Lpkg/Jvm$Inner;)V", "", "", "", "jvm").node/kind function
 
 //- FuncJvm=vname("pkg.Jvm.func(ILjava/lang/Object;)V", "", "", "", "jvm").node/kind function
 //- Param0Jvm=vname("pkg.Jvm.func(ILjava/lang/Object;)V.param0", "", "", "", "jvm").node/kind variable
@@ -21,14 +27,14 @@
 //- Param0Jvm.subkind local/parameter
 //- Param1Jvm.subkind local/parameter
 
-//- GenericJvm=vname("pkg.Jvm.Generic", "", "", "", "jvm").node/kind record
-//- TFieldJvm=vname("pkg.Jvm.Generic.tfield", "", "", "", "jvm").node/kind variable
-//- TMethodJvm=vname("pkg.Jvm.Generic.tmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
-//- TListMethodJvm=vname("pkg.Jvm.Generic.tlistmethod(Ljava/util/List;)V", "", "", "", "jvm").node/kind function
-//- TListRetMethodJvm=vname("pkg.Jvm.Generic.tlistretmethod()Ljava/util/List;", "", "", "", "jvm").node/kind function
+//- GenericJvm=vname("pkg.Jvm$Generic", "", "", "", "jvm").node/kind record
+//- TFieldJvm=vname("pkg.Jvm$Generic.tfield", "", "", "", "jvm").node/kind variable
+//- TMethodJvm=vname("pkg.Jvm$Generic.tmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
+//- TListMethodJvm=vname("pkg.Jvm$Generic.tlistmethod(Ljava/util/List;)V", "", "", "", "jvm").node/kind function
+//- TListRetMethodJvm=vname("pkg.Jvm$Generic.tlistretmethod()Ljava/util/List;", "", "", "", "jvm").node/kind function
 
-//- MBGenericJvm=vname("pkg.Jvm.MultipleBoundGeneric", "", "", "", "jvm").node/kind record
-//- MBTMethodJvm=vname("pkg.Jvm.MultipleBoundGeneric.mbtmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
+//- MBGenericJvm=vname("pkg.Jvm$MultipleBoundGeneric", "", "", "", "jvm").node/kind record
+//- MBTMethodJvm=vname("pkg.Jvm$MultipleBoundGeneric.mbtmethod(Ljava/lang/Integer;)V", "", "", "", "jvm").node/kind function
 
 //- NopeJvm=vname("pkg.Jvm.nope()Ljava/lang/Object;", "", "", "", "jvm").node/kind function
 


### PR DESCRIPTION
Previously we emitted `pkg.Outer.Inner`, but at the JVM level
there are no inner classes, and `Inner` compiles to a top-level
class in pkg `pkg` named `Outer$Inner`. So we should emit accordingly.

The new `methodWithInnerParam` test exposes the issue - prior to this
change, the source and binary indexers would have emitted different
method signatures.