### PR TITLE
Add tests to ensure all used proto types and functions are registered with Beam

### DIFF
--- a/kythe/go/serving/pipeline/BUILD
+++ b/kythe/go/serving/pipeline/BUILD
@@ -46,6 +46,7 @@ go_test(
     srcs = ["beam_test.go"],
     library = ":pipeline",
     deps = [
+        "//kythe/go/serving/pipeline/beamtest",
         "//kythe/proto:common_go_proto",
         "@com_github_apache_beam//sdks/go/pkg/beam/testing/passert:go_default_library",
         "@com_github_apache_beam//sdks/go/pkg/beam/testing/ptest:go_default_library",

--- a/kythe/go/serving/pipeline/beam.go
+++ b/kythe/go/serving/pipeline/beam.go
@@ -42,18 +42,30 @@ import (
 )
 
 func init() {
+	beam.RegisterFunction(defToDecorPiece)
+	beam.RegisterFunction(fileToDecorPiece)
 	beam.RegisterFunction(keyByPath)
 	beam.RegisterFunction(moveSourceToKey)
+	beam.RegisterFunction(nodeToDecorPiece)
+	beam.RegisterFunction(refToDecorPiece)
+	beam.RegisterFunction(toDefinition)
 	beam.RegisterFunction(toEnclosingFile)
 	beam.RegisterFunction(toFiles)
 	beam.RegisterFunction(toRefs)
 
-	beam.RegisterFunction(fileToDecorPiece)
-	beam.RegisterFunction(nodeToDecorPiece)
-	beam.RegisterFunction(refToDecorPiece)
-
 	beam.RegisterType(reflect.TypeOf((*combineDecorPieces)(nil)).Elem())
 	beam.RegisterType(reflect.TypeOf((*ticketKey)(nil)).Elem())
+
+	beam.RegisterType(reflect.TypeOf((*ppb.DecorationPiece)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*ppb.Node)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*ppb.Reference)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*spb.Entry)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*spb.VName)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*srvpb.CorpusRoots)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*srvpb.ExpandedAnchor)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*srvpb.File)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*srvpb.FileDecorations)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*srvpb.FileDirectory)(nil)).Elem())
 }
 
 // KytheBeam controls the lifetime and generation of PCollections in the Kythe

--- a/kythe/go/serving/pipeline/beam_test.go
+++ b/kythe/go/serving/pipeline/beam_test.go
@@ -19,6 +19,8 @@ package pipeline
 import (
 	"testing"
 
+	"kythe.io/kythe/go/serving/pipeline/beamtest"
+
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/ptest"
@@ -363,5 +365,25 @@ func TestDecorations_targetDefinition(t *testing.T) {
 
 	if err := ptest.Run(p); err != nil {
 		t.Fatalf("Pipeline error: %+v", err)
+	}
+}
+
+func TestFileTree_registrations(t *testing.T) {
+	testNodes := []*ppb.Node{{}}
+	p, s, nodes := ptest.CreateList(testNodes)
+	k := FromNodes(s, nodes)
+	k.CorpusRoots()
+	k.Directories()
+	if err := beamtest.CheckRegistrations(p); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDecorations_registrations(t *testing.T) {
+	testNodes := []*ppb.Node{{}}
+	p, s, nodes := ptest.CreateList(testNodes)
+	FromNodes(s, nodes).Decorations()
+	if err := beamtest.CheckRegistrations(p); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/kythe/go/serving/pipeline/beamtest/BUILD
+++ b/kythe/go/serving/pipeline/beamtest/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//kythe:default_visibility"])
+
+load("//tools:build_rules/shims.bzl", "go_library")
+
+go_library(
+    name = "beamtest",
+    srcs = ["beamtest.go"],
+    deps = [
+        "@com_github_apache_beam//sdks/go/pkg/beam:go_default_library",
+        "@com_github_apache_beam//sdks/go/pkg/beam/core/runtime:go_default_library",
+        "@com_github_apache_beam//sdks/go/pkg/beam/core/util/reflectx:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
+    ],
+)

--- a/kythe/go/serving/pipeline/beamtest/beamtest.go
+++ b/kythe/go/serving/pipeline/beamtest/beamtest.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package beamtest contains utilities to test Apache Beam pipelines.
+package beamtest
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/golang/protobuf/proto"
+)
+
+// CheckRegistrations returns an error if p uses any non-registered types.
+func CheckRegistrations(p *beam.Pipeline) error {
+	edges, nodes, err := p.Build()
+	if err != nil {
+		return fmt.Errorf("invalid pipeline: %v", err)
+	}
+	for _, n := range nodes {
+		if err := checkFullType(n.Type()); err != nil {
+			return err
+		}
+	}
+	for _, e := range edges {
+		if fn := e.DoFn; fn != nil {
+			if fn.Recv != nil {
+				if err := checkFnType(reflect.TypeOf(fn.Recv)); err != nil {
+					return err
+				}
+			} else if _, err := runtime.ResolveFunction(fn.Name(), fn.Fn.Fn.Type()); err != nil {
+				return fmt.Errorf("error resolving function: %v", err)
+			}
+		}
+	}
+	return nil
+}
+
+var protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+
+func checkType(t reflect.Type) error {
+	key, keyValid := runtime.TypeKey(reflectx.SkipPtr(t))
+	if !keyValid {
+		return nil
+	} else if _, ok := runtime.LookupType(key); !ok && t.Implements(protoMessageType) {
+		return fmt.Errorf("unregistered proto.Message type: %v", t)
+	}
+	return nil
+}
+
+func checkFnType(t reflect.Type) error {
+	key, keyValid := runtime.TypeKey(reflectx.SkipPtr(t))
+	if !keyValid {
+		return nil
+	} else if _, ok := runtime.LookupType(key); !ok {
+		return fmt.Errorf("unregistered function type: %v", t)
+	}
+	return nil
+}
+
+func checkFullType(t beam.FullType) error {
+	if err := checkType(t.Type()); err != nil {
+		return err
+	}
+	for _, c := range t.Components() {
+		if err := checkFullType(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kythe/go/serving/tools/write_tables/BUILD
+++ b/kythe/go/serving/tools/write_tables/BUILD
@@ -16,8 +16,6 @@ go_binary(
         "//kythe/go/storage/stream",
         "//kythe/go/util/flagutil",
         "//kythe/go/util/profile",
-        "//kythe/proto:pipeline_go_proto",
-        "//kythe/proto:serving_go_proto",
         "//kythe/proto:storage_go_proto",
         "//third_party/beam:runner_disksort",
         "@com_github_apache_beam//sdks/go/pkg/beam:go_default_library",

--- a/kythe/go/serving/tools/write_tables/write_tables.go
+++ b/kythe/go/serving/tools/write_tables/write_tables.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"flag"
 	"log"
-	"reflect"
 
 	"kythe.io/kythe/go/platform/vfs"
 	"kythe.io/kythe/go/services/graphstore"
@@ -35,8 +34,6 @@ import (
 	"kythe.io/kythe/go/util/flagutil"
 	"kythe.io/kythe/go/util/profile"
 
-	ppb "kythe.io/kythe/proto/pipeline_go_proto"
-	srvpb "kythe.io/kythe/proto/serving_go_proto"
 	spb "kythe.io/kythe/proto/storage_go_proto"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
@@ -123,13 +120,6 @@ func main() {
 	}); err != nil {
 		log.Fatal("FATAL ERROR: ", err)
 	}
-}
-
-func init() {
-	beam.RegisterType(reflect.TypeOf((*ppb.Node)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*spb.Entry)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*spb.VName)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*srvpb.FileDecorations)(nil)).Elem())
 }
 
 func runExperimentalBeamPipeline(ctx context.Context) error {


### PR DESCRIPTION
Unregistered types/functions become runtime panics on remote Beam runners.