### PR TITLE
kzip: tolerate an empty units directory entry

### DIFF
--- a/kythe/go/platform/kzip/kzip.go
+++ b/kythe/go/platform/kzip/kzip.go
@@ -195,6 +195,9 @@ func (r *Reader) Scan(f func(*Unit) error) error {
 			break
 		}
 		digest := strings.TrimPrefix(file.Name, prefix)
+		if digest == "" {
+			continue // tolerate an empty units directory entry
+		}
 		unit, err := readUnit(digest, file)
 		if err != nil {
 			return err


### PR DESCRIPTION
If the zip archive contains a root/units/ entry to represent the base
directory, ensure the Scan function doesn't attempt to read the file, as it is
not a meaningful unit. Such directories are never created by this library, but
may be inserted by other generators.