### PR TITLE
Add copy output step to the end of kythe maven extraction.

### DIFF
--- a/kythe/go/extractors/config/config_parser.go
+++ b/kythe/go/extractors/config/config_parser.go
@@ -47,16 +47,6 @@ const (
 	repoVolumeEnv = "KYTHE_ROOT_DIRECTORY"
 )
 
-// Format the base configuration including the base image, volume hooks, and working dir.
-var baseConfig = fmt.Sprintf(`
-FROM %[1]s
-VOLUME %[2]s
-ENV %[3]s=%[2]s
-VOLUME %[4]s
-ENV %[5]s=%[4]s
-WORKDIR %[2]s
-`, defaultBaseImage, DefaultRepoVolume, repoVolumeEnv, DefaultOutputVolume, outputVolumeEnv)
-
 // imageSettings allows for optionally controlling a known input repo and
 // output dir.  Leaving these unset just defaults to /repo and /out for use in
 // an ephemeral Docker container.
@@ -85,7 +75,8 @@ func newImage(config *ecpb.ExtractionConfiguration, settings imageSettings) ([]b
 		fmt.Fprintf(&buf, "FROM %s as %s\n", image.Uri, image.Name)
 	}
 
-	// Format the base configuration into the current config.
+	// Format the base configuration including the base image, volume hooks, and
+	// working dir.
 	fmt.Fprintf(&buf, `
 FROM %[1]s
 VOLUME %[2]s

--- a/kythe/go/extractors/config/extractor.go
+++ b/kythe/go/extractors/config/extractor.go
@@ -56,15 +56,23 @@ type Repo struct {
 	// default config.
 	ConfigPath string
 
-	// An optional path that dictates where temporary repo copies should go.
-	// TODO(#156): this should be removed as soon as we refactor code to no
-	// longer use docker-in-docker.
+	// TODO(#156): these two should be remoevd when docker-in-docker is
+	// removed.  Currently necessary for docker-in-docker because regular volume
+	// mapping uses the outermost context instead of correctly pushing the
+	// first layer docker container's empeheral volume into the innermost
+	// layer.
+	//
+	// When running inside a docker container, these should be set to match
+	// their corresponding volumes.
+	// When not running inside a docker cotnainer, these can be left unset,
+	// in which case an ephemeral temp directory is used for TempRepoDir, and
+	// output is written directly into OutputPath from mvn-extract.sh.
+
+	// An optional temporary repo path to copy the input repo to.
 	TempRepoDir string
 
-	// An optional path that dicates where temporary output should go before
-	// being copied to the real OutputPath.
-	// TODO(#156): this is another code smell that exists only to make
-	// docker-in-docker less kludgy to use.
+	// An optional temporary directory path to write output before copying to
+	// OutputPath.
 	TempOutDir string
 }
 

--- a/kythe/go/extractors/config/extractor.go
+++ b/kythe/go/extractors/config/extractor.go
@@ -88,7 +88,7 @@ func (r Repo) localClone(ctx context.Context, tmpDir string) error {
 		skipDir: gitDir,
 	})
 	if err != nil {
-		return fmt.Errorf("copying repo: %v")
+		return fmt.Errorf("copying repo: %v", err)
 	}
 	return nil
 }

--- a/kythe/go/extractors/config/extractor.go
+++ b/kythe/go/extractors/config/extractor.go
@@ -60,15 +60,21 @@ type Repo struct {
 	// TODO(#156): this should be removed as soon as we refactor code to no
 	// longer use docker-in-docker.
 	TempRepoDir string
+
+	// An optional path that dicates where temporary output should go before
+	// being copied to the real OutputPath.
+	// TODO(#156): this is another code smell that exists only to make
+	// docker-in-docker less kludgy to use.
+	TempOutDir string
 }
 
 func (r Repo) gitClone(ctx context.Context, tmpDir string) error {
-	// TODO(#154): strongly consider go-git instead of os.exec
 	return GitClone(ctx, r.Git, tmpDir)
 }
 
 // GitClone is a convenience wrapper around a commandline git clone call.
 func GitClone(ctx context.Context, repo, outputPath string) error {
+	// TODO(#154): strongly consider go-git instead of os.exec
 	return exec.CommandContext(ctx, "git", "clone", repo, outputPath).Run()
 }
 
@@ -76,34 +82,54 @@ func (r Repo) localClone(ctx context.Context, tmpDir string) error {
 	gitDir := filepath.Join(r.Local, ".git")
 	// TODO(danielmoy): consider extracting all or part of this
 	// to a more common place.
-	return filepath.Walk(r.Local, func(path string, info os.FileInfo, err error) error {
+	err := copyDir(copyArgs{
+		out:     tmpDir,
+		in:      r.Local,
+		skipDir: gitDir,
+	})
+	if err != nil {
+		return fmt.Errorf("copying repo: %v")
+	}
+	return nil
+}
+
+type copyArgs struct {
+	out     string
+	in      string
+	skipDir string
+}
+
+// copyDir copies files from in to out. If skipDir is not empty, it skips any
+// directories matching that prefix.
+func copyDir(args copyArgs) error {
+	return filepath.Walk(args.in, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if r.Local == path {
+		if args.in == path {
 			// Intentionally do nothing for base dir.
 			return nil
 		}
-		if filepath.HasPrefix(path, gitDir) {
+		if args.skipDir != "" && filepath.HasPrefix(path, args.skipDir) {
 			return filepath.SkipDir
 		}
-		rel, err := filepath.Rel(r.Local, path)
+		rel, err := filepath.Rel(args.in, path)
 		if err != nil {
 			return err
 		}
-		outPath := filepath.Join(tmpDir, rel)
+		outPath := filepath.Join(args.out, rel)
 		if info.Mode().IsRegular() {
 			if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
 				return fmt.Errorf("failed to make dir: %v", err)
 			}
 			inf, err := os.Open(path)
 			if err != nil {
-				return fmt.Errorf("failed to open input file from repo: %v", err)
+				return fmt.Errorf("failed to open input file: %v", err)
 			}
 			defer inf.Close()
 			of, err := os.Create(outPath)
 			if err != nil {
-				return fmt.Errorf("failed to open output file for repo copy: %v", err)
+				return fmt.Errorf("failed to open output file for copy: %v", err)
 			}
 			if _, err := io.Copy(of, inf); err != nil {
 				of.Close()
@@ -193,9 +219,13 @@ func ExtractRepo(ctx context.Context, repo Repo) error {
 		return fmt.Errorf("reading config file: %v", err)
 	}
 
+	outPath := repo.OutputPath
+	if repo.TempOutDir != "" {
+		outPath = repo.TempOutDir
+	}
 	err = createImage(extractionConfig, imageSettings{
 		RepoDir:   repo.TempRepoDir,
-		OutputDir: repo.OutputPath,
+		OutputDir: outPath,
 	}, extractionDockerFile.Name())
 	if err != nil {
 		return fmt.Errorf("creating extraction image: %v", err)
@@ -214,7 +244,7 @@ func ExtractRepo(ctx context.Context, repo Repo) error {
 		targetRepoDir = DefaultRepoVolume
 	}
 	// run the extraction
-	commandArgs := []string{"run", "--rm", "-v", fmt.Sprintf("%s:%s", repo.OutputPath, repo.OutputPath)}
+	commandArgs := []string{"run", "--rm"}
 	// Check and see if we're living inside a docker image.
 	// TODO(#156): This is an undesireable smell from docker-in-docker which
 	// should be removed when we refactor the inner docker away.
@@ -223,16 +253,26 @@ func ExtractRepo(ctx context.Context, repo Repo) error {
 		// -v /input/repo:/input, it actually takes /input/repo from the
 		// *outermost* docker container, which is not what we want! Instead rely
 		// on --volumes-from to copy in all the correct volumes.
+		// Similar logic holds for output directory mapping.
 		commandArgs = append(commandArgs, "--volumes-from", id)
 	} else {
-		commandArgs = append(commandArgs, fmt.Sprintf("%s:%s", repoDir, targetRepoDir), "-v")
+		commandArgs = append(commandArgs, "-v", fmt.Sprintf("%s:%s", repo.OutputPath, outPath), "-v", fmt.Sprintf("%s:%s", repoDir, targetRepoDir))
 	}
 	commandArgs = append(commandArgs, "-t", imageTag)
 	output, err = exec.CommandContext(ctx, "docker", commandArgs...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("extracting repo: %v\nCommand output: %s", err, string(output))
 	}
-
+	if repo.TempOutDir != "" {
+		// TODO(#156): after removing docker-in-docker we can ax this copy.
+		err := copyDir(copyArgs{
+			out: repo.OutputPath,
+			in:  repo.TempOutDir,
+		})
+		if err != nil {
+			return fmt.Errorf("copying output: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/kythe/go/platform/tools/extraction/extractrepo/Dockerfile
+++ b/kythe/go/platform/tools/extraction/extractrepo/Dockerfile
@@ -20,15 +20,17 @@
 # $ bazel build kythe/go/platforms/tools/extraction/extractrepo:extractrepo
 # $ cp bazel-bin/kythe/go/platform/tools/extraction/extractrepo/linux_amd64_stripped/extractrepo kythe/go/platform/tools/extraction/extractrepo
 # $ docker build --tag test-extract kythe/go/platform/tools/extraction/extractrepo/.
-# $ docker run -i --volume /tmp/input --volume /tmp/output -v ~/some/mvn/repo:/tmp/repo -v /tmp/output:/tmp/output -v /var/run/docker.sock:/var/run/docker.sock -t test-extract
+# $ docker run -i -v /some/mvn/repo:/repo -v /some/output/dir:/output -v /var/run/docker.sock:/var/run/docker.sock -t kythe-mvn-extract-0.2
 #
 # It will deposit .kindex files into /tmp/output.
 
 FROM docker:dind
 
+# TODO(#156): These volumes are only necessary for docker-in-docker, remove
+# them in the future.
 VOLUME /tmp/input
-VOLUME /tmp/output
+VOLUME /tmp/out
 
 ADD extractrepo extractrepo
 
-ENTRYPOINT ["/extractrepo", "-local", "/tmp/repo", "-output", "/tmp/output", "-tmp_repo_dir", "/tmp/input"]
+ENTRYPOINT ["/extractrepo", "-local", "/repo", "-output", "/output", "-tmp_repo_dir", "/tmp/input", "-tmp_out_dir", "/tmp/out"]

--- a/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
+++ b/kythe/go/platform/tools/extraction/extractrepo/extractrepo.go
@@ -41,8 +41,9 @@ var (
 	outputPath = flag.String("output", "", "Path for output kindex file")
 	configPath = flag.String("config", "", "Path for the JSON extraction configuration file")
 	timeout    = flag.Duration("timeout", 2*time.Minute, "Timeout for extraction")
-	// TODO(#156): Remove this flag after we get rid of docker-in-docker.
+	// TODO(#156): Remove these flags after we get rid of docker-in-docker.
 	tempRepoDir = flag.String("tmp_repo_dir", "", "Path for inner docker copy of input repo. Should be an empty directory.")
+	tempOutDir  = flag.String("tmp_out_dir", "", "Path for inner docker copy of output. Should be an empty directory.")
 )
 
 func init() {
@@ -97,6 +98,11 @@ func verifyFlags() {
 		log.Printf("Error: -tmp_repo_dir %q should be an empty directory", *tempRepoDir)
 	}
 
+	if *tempOutDir != "" && !isEmptyDir(*tempOutDir) {
+		hasError = true
+		log.Printf("Error: -tmp_out_dir %q should be an empty directory", *tempOutDir)
+	}
+
 	if hasError {
 		os.Exit(1)
 	}
@@ -129,6 +135,7 @@ func main() {
 		OutputPath:  *outputPath,
 		ConfigPath:  *configPath,
 		TempRepoDir: *tempRepoDir,
+		TempOutDir:  *tempOutDir,
 	}
 	if err := config.ExtractRepo(ctx, repo); err != nil {
 		log.Fatalf("Failed to extract repo: %v", err)


### PR DESCRIPTION
Yet another affordance for docker-in-docker described in #156, which we
probably should get rid of long term.  For the short/medium term though,
this makes calling the eventual docker image a lot nicer, since we can
specify output to arbitrary top-level directories.