### PR TITLE
xrefs_test.go: remove dead code and associated imports

### DIFF
--- a/kythe/go/serving/xrefs/BUILD
+++ b/kythe/go/serving/xrefs/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//kythe/proto:xref_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
+        "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//trace:go_default_library",

--- a/kythe/go/serving/xrefs/BUILD
+++ b/kythe/go/serving/xrefs/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//kythe/proto:xref_go_proto",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
-        "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//trace:go_default_library",

--- a/kythe/go/serving/xrefs/xrefs_test.go
+++ b/kythe/go/serving/xrefs/xrefs_test.go
@@ -27,7 +27,6 @@ import (
 	"kythe.io/kythe/go/test/testutil"
 	"kythe.io/kythe/go/util/kytheuri"
 
-	"bitbucket.org/creachadair/stringset"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
@@ -1234,10 +1233,6 @@ type testTable struct {
 
 func (tbl *testTable) Construct(t *testing.T) *Table {
 	p := make(testProtoTable)
-	var tickets stringset.Set
-	for _, n := range tbl.Nodes {
-		tickets.Add(n.Ticket)
-	}
 	for _, d := range tbl.Decorations {
 		testutil.FatalOnErrT(t, "Error writing file decorations: %v", p.Put(ctx, DecorationsKey(mustFix(t, d.File.Ticket)), d))
 	}


### PR DESCRIPTION
`tickets` is written, but never read.