### PR TITLE
Reduce todo log level from warn to log

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -137,7 +137,7 @@ class Vistor {
     const file = path.relative(this.sourceRoot, sourceFile.fileName);
     const {line, character} =
         ts.getLineAndCharacterOfPosition(sourceFile, node.getStart());
-    console.warn(`TODO: ${file}:${line}:${character}: ${message}`);
+    console.log(`TODO: ${file}:${line}:${character}: ${message}`);
   }
 
   /**


### PR DESCRIPTION
This helps clean up the warning messages from the ts indexer to make it easier to see real warnings.