### PR TITLE
Inherit language from file vname when creating new anchor.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/base/KytheEntrySets.java
@@ -169,6 +169,7 @@ public class KytheEntrySets {
     EntrySet.Builder builder =
         newNode(NodeKind.ANCHOR)
             .setCorpusPath(CorpusPath.fromVName(fileVName))
+            .setLanguage(fileVName.getLanguage())
             .addSignatureSalt(fileVName)
             .setProperty("loc/start", "" + loc.getStart())
             .setProperty("loc/end", "" + loc.getEnd());
@@ -436,6 +437,11 @@ public class KytheEntrySets {
     @Override
     public NodeBuilder setProperty(String name, String value) {
       return (NodeBuilder) super.setProperty(name, value);
+    }
+
+    public NodeBuilder setLanguage(String language) {
+      sourceBuilder.setLanguage(language);
+      return this;
     }
   }
 


### PR DESCRIPTION
This helps to create anchors from other languages. For example JavaScript indexer can create "imputes" edges pointing from .java files.

Tested:
  bazel test //kythe/javatests/...