### PR TITLE
kytheuri: Speed up encoding a URI to a string.

### DIFF
--- a/kythe/go/util/kytheuri/bench_test.go
+++ b/kythe/go/util/kytheuri/bench_test.go
@@ -28,3 +28,14 @@ func BenchmarkParse(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkString(b *testing.B) {
+	p, err := Parse(benchURI)
+	if err != nil {
+		panic(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.Encode().String()
+	}
+}

--- a/kythe/go/util/kytheuri/uri.go
+++ b/kythe/go/util/kytheuri/uri.go
@@ -20,7 +20,6 @@
 package kytheuri
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path"
@@ -104,7 +103,8 @@ func (r *Raw) String() string {
 	if r == nil {
 		return Scheme
 	}
-	buf := bytes.NewBufferString(Scheme)
+	var buf strings.Builder
+	buf.WriteString(Scheme)
 	if c := r.URI.Corpus; c != "" {
 		buf.WriteString("//")
 		buf.WriteString(c)
@@ -112,19 +112,14 @@ func (r *Raw) String() string {
 
 	// Pack up the query arguments. Order matters here, so that we can preserve
 	// a canonical string format.
-	var query []string
 	if s := r.URI.Language; s != "" {
-		query = append(query, "lang="+s)
+		buf.WriteString("?lang=" + s)
 	}
 	if s := r.URI.Path; s != "" {
-		query = append(query, "path="+s)
+		buf.WriteString("?path=" + s)
 	}
 	if s := r.URI.Root; s != "" {
-		query = append(query, "root="+s)
-	}
-	if len(query) != 0 {
-		buf.WriteByte('?')
-		buf.WriteString(strings.Join(query, "?"))
+		buf.WriteString("?root=" + s)
 	}
 
 	// If there is a signature, add that in as well.

--- a/kythe/go/util/kytheuri/uri.go
+++ b/kythe/go/util/kytheuri/uri.go
@@ -104,6 +104,13 @@ func (r *Raw) String() string {
 		return Scheme
 	}
 	var buf strings.Builder
+	buf.Grow(len(Scheme) +
+		2 + len(r.URI.Corpus) + // "//" + corpus
+		6 + len(r.URI.Language) + // "?lang=" + string
+		6 + len(r.URI.Path) + // "?path=" + string
+		6 + len(r.URI.Root) + // "?root=" + string
+		1 + len(r.URI.Signature), // "#" + string
+	)
 	buf.WriteString(Scheme)
 	if c := r.URI.Corpus; c != "" {
 		buf.WriteString("//")


### PR DESCRIPTION
Use a strings.Builder to reduce allocation overheads. This gives us a 32%
reduction in runtime for Kythe URI encoding on the parsing benchmark sample.

  BenchmarkString-8        1000000              2331 ns/op
  BenchmarkOldString-8      500000              3446 ns/op