### PR TITLE
kytheuri: Git rid of some additional allocations.

### DIFF
--- a/kythe/go/util/kytheuri/uri.go
+++ b/kythe/go/util/kytheuri/uri.go
@@ -120,13 +120,16 @@ func (r *Raw) String() string {
 	// Pack up the query arguments. Order matters here, so that we can preserve
 	// a canonical string format.
 	if s := r.URI.Language; s != "" {
-		buf.WriteString("?lang=" + s)
+		buf.WriteString("?lang=")
+		buf.WriteString(s)
 	}
 	if s := r.URI.Path; s != "" {
-		buf.WriteString("?path=" + s)
+		buf.WriteString("?path=")
+		buf.WriteString(s)
 	}
 	if s := r.URI.Root; s != "" {
-		buf.WriteString("?root=" + s)
+		buf.WriteString("?root=")
+		buf.WriteString(s)
 	}
 
 	// If there is a signature, add that in as well.


### PR DESCRIPTION
This drops the runtime by another 4.5%.

    BenchmarkOldString-8     1000000              2061 ns/op
    BenchmarkString-8        1000000              1968 ns/op

The crux of the change is to avoid allocating to concatenate the static strings
with their prefixes. The swap for the function call wins the round.