### PR TITLE
Riegeli: support decoding proto groups and non-proto records

### DIFF
--- a/kythe/go/util/riegeli/transpose_test.go
+++ b/kythe/go/util/riegeli/transpose_test.go
@@ -23,6 +23,9 @@ import (
 
 // TODO(schroederc): add more tests once an encoder is available
 
+// TODO(schroederc): test non-proto records support
+// TODO(schroederc): test deprecated protobuf "groups" support
+
 func TestBackwardWriter(t *testing.T) {
 	pieces := []string{"a", "b", "ccc", "dd", "eee"}
 


### PR DESCRIPTION
This is mostly to remove the panics from the decoder.  It'll be easier to test these features once the encoder is working.