### PR TITLE
Migrate from java_common.create_provider to new constructor JavaInfo() [1]

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("//:version.bzl", "check_version")
 
 # Check that the user has a version between our minimum supported version of
 # Bazel and our maximum supported version of Bazel.
-check_version("0.13", "0.15")
+check_version("0.14", "0.15")
 
 load("//tools/cpp:clang_configure.bzl", "clang_configure")
 

--- a/tools/build_rules/verifier_test/verifier_test.bzl
+++ b/tools/build_rules/verifier_test/verifier_test.bzl
@@ -159,10 +159,7 @@ def _java_extract_kindex_impl(ctx):
     host_javabase = ctx.attr._host_javabase,
     source_files = ctx.files.srcs,
     output = jar,
-    deps = [java_common.create_provider(
-      compile_time_jars = jars,
-      use_ijar = False,
-    )],
+    deps = [JavaInfo(output_jar = curr_jar, compile_jar = curr_jar) for curr_jar in jars],
   )
 
   args = ctx.attr.opts + [


### PR DESCRIPTION
java_common.create_provider will be deprecated soon.

[1] https://docs.bazel.build/versions/master/skylark/lib/JavaInfo.html#JavaInfo