### PR TITLE
properly handle utf16 surrogate pairs

### DIFF
--- a/kythe/typescript/package.json
+++ b/kythe/typescript/package.json
@@ -6,13 +6,19 @@
     "watch": "tsc -w",
     "browse": "node indexer.js tsconfig.json | ./browse",
     "test": "yarn build && yarn runtest",
-    "runtest": "node test.js",
+    "runtest": "yarn unit_test && yarn e2e_test",
+    "e2e_test": "node test.js",
+    "unit_test": "jasmine utf8_test.js",
     "fmt": "clang-format -i *.ts"
   },
   "dependencies": {
-    "@types/node": "^7.0.4",
     "source-map-support": "^0.4.11",
     "typescript": "~2.8.3"
+  },
+  "devDependencies": {
+    "@types/jasmine": "^2.8.8",
+    "@types/node": "^7.0.4",
+    "jasmine": "^3.1.0"
   },
   "license": "Apache-2.0"
 }

--- a/kythe/typescript/utf8_test.ts
+++ b/kythe/typescript/utf8_test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {OffsetTable} from './utf8';
+
+describe('utf8 create offset table', () => {
+  it('should handle 1-byte character encoding', () => {
+    const buf = Buffer.from('123');
+    const table = new OffsetTable(buf, 1);
+    expect(table.buf.length).toEqual(3);
+    expect(table.offsets).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+  });
+
+  it('should handle 3-byte character encoding', () => {
+    const buf = Buffer.from('12•3');
+    const table = new OffsetTable(buf, 1);
+    // Number of bytes = 1 + 1 + 3 + 1 = 6
+    expect(table.buf.length).toEqual(6);
+    expect(table.offsets).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [3, 5],
+      [4, 6],
+    ]);
+  });
+
+  it('should handle 4-byte character encoding', () => {
+    const buf = Buffer.from('12🐶3');
+    const table = new OffsetTable(buf, 1);
+    // Number of bytes = 1 + 1 + 4 + 1 = 7
+    expect(table.buf.length).toEqual(7);
+    expect(table.offsets).toEqual([
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      // utf16 offset 3 is skipped because it's within a surrogate pair.
+      [4, 6],
+      [5, 7],
+    ]);
+  });
+
+  it('should handle mix of 3-byte and 4-byte character encoding', () => {
+    const buf = Buffer.from('🐶•🐶•');
+    const table = new OffsetTable(buf, 1);
+    // Number of bytes = 4 + 3 + 4 + 3 = 14
+    expect(table.buf.length).toEqual(14);
+    expect(table.offsets).toEqual([
+      [0, 0],
+      [2, 4],
+      [3, 7],
+      [5, 11],
+      [6, 14],
+    ]);
+  });
+
+  it('should work when span size is greater than 1', () => {
+    const buf = Buffer.from('🐶•🐶•');
+    const table = new OffsetTable(buf, 2);
+    // Number of bytes = 4 + 3 + 4 + 3 = 14
+    expect(table.buf.length).toEqual(14);
+    expect(table.offsets).toEqual([
+      [0, 0],
+      [2, 4],
+      // utf16 offset 4 is skipped because it's within a surrogate pair.
+      // Backoff to use offset 5.
+      [5, 11],
+      [6, 14],
+    ]);
+  });
+
+  it('should work when span size is greater than Buffer size', () => {
+    const buf = Buffer.from('🐶•🐶•');
+    const table = new OffsetTable(buf, 32);
+    // Number of bytes = 4 + 3 + 4 + 3 = 14
+    expect(table.buf.length).toEqual(14);
+    expect(table.offsets).toEqual([
+      [0, 0],
+    ]);
+  });
+});
+
+describe('utf8 lookup', () => {
+  it('should throw an error at invalid lookup positions', () => {
+    const buf = Buffer.from('🐶');
+    const table = new OffsetTable(buf, 1);
+    expect(() => table.lookup(0)).not.toThrow();
+    // offset 1 is within a surrogate pair so it's invalid.
+    expect(() => table.lookup(1)).toThrowError('The lookup offset is invalid');
+  });
+
+  it('should find the offsets when span size is greater than 1', () => {
+    const buf = Buffer.from('🐶•🐶•');
+    const table = new OffsetTable(buf, 32);
+    expect(table.lookup(0)).toEqual(0);
+    expect(table.lookup(2)).toEqual(4);
+    expect(table.lookup(3)).toEqual(7);
+    expect(table.lookup(5)).toEqual(11);
+    expect(table.lookup(6)).toEqual(14);
+  });
+
+  it('should find the offsets when there are multiple spans', () => {
+    const buf = Buffer.from('🐶•🐶•');
+    const table = new OffsetTable(buf, 2);
+    expect(table.lookup(0)).toEqual(0);
+    expect(table.lookup(2)).toEqual(4);
+    expect(table.lookup(3)).toEqual(7);
+    expect(table.lookup(5)).toEqual(11);
+    expect(table.lookup(6)).toEqual(14);
+  });
+});

--- a/kythe/typescript/yarn.lock
+++ b/kythe/typescript/yarn.lock
@@ -2,9 +2,81 @@
 # yarn lockfile v1
 
 
+"@types/jasmine@^2.8.8":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.8.tgz#bf53a7d193ea8b03867a38bfdb4fbb0e0bf066c9"
+
 "@types/node@^7.0.4":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.4.tgz#9aabc135979ded383325749f508894c662948c8b"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+glob@^7.0.6:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+jasmine-core@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.1.0.tgz#a4785e135d5df65024dfc9224953df585bd2766c"
+
+jasmine@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-3.1.0.tgz#2bd59fd7ec6ec0e8acb64e09f45a68ed2ad1952a"
+  dependencies:
+    glob "^7.0.6"
+    jasmine-core "~3.1.0"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 source-map-support@^0.4.11:
   version "0.4.11"
@@ -19,3 +91,7 @@ source-map@^0.5.3:
 typescript@~2.8.3:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
The 'utf8' module maps nodejs UTF-16 offsets <-> Kythe UTF-8 offsets.
Because of surrogate pairs, a single code point in UTF-8 may be multiple
UTF-16 code units.

The fix also includes a unit test for the module that includes some
surrogate pairs.  To run this unit test we bring in a dependency on
Jasmine and adjust the test-running machinery to run both the unit
test and the end-to-end test.

This code was mostly written by Bowen Ni <bowen1897@gmail.com>; I just
added the Jasmine glue for running as part of open source Kythe.