### PR TITLE
Add comment pointing to maven docs on compiler config bits.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/tools/pom_compiler_plugin_fragment.xml
+++ b/kythe/java/com/google/devtools/kythe/platform/tools/pom_compiler_plugin_fragment.xml
@@ -14,6 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+<!--
+For an explanation of why this is set, see the maven docs:
+
+https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html
+-->
 <plugin>
   <groupId>org.apache.maven.plugins</groupId>
   <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Mostly just a reminder to myself so I don't have to keep hunting the same doc every time I forget.