### PR TITLE
Switch ts log back to warn

### DIFF
--- a/kythe/typescript/indexer.ts
+++ b/kythe/typescript/indexer.ts
@@ -137,7 +137,7 @@ class Vistor {
     const file = path.relative(this.sourceRoot, sourceFile.fileName);
     const {line, character} =
         ts.getLineAndCharacterOfPosition(sourceFile, node.getStart());
-    console.log(`TODO: ${file}:${line}:${character}: ${message}`);
+    console.warn(`TODO: ${file}:${line}:${character}: ${message}`);
   }
 
   /**


### PR DESCRIPTION
console.log writes to stdout which can cause problems with the indexing pipeline. Put the log to stderr back in for now.

This undoes https://github.com/google/kythe/commit/8f53ded74543efad087aca592b17ff049f74f5ae