### PR TITLE
Use find_cpp_toolchain in compile_commands.bzl

### DIFF
--- a/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
+++ b/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
@@ -1,5 +1,7 @@
 """Rule for generating compile_commands.json.in with appropriate inlcude directories."""
 
+load("//third_party/kythe:tools/build_rules/verifier_test/toolchain_utils.bzl", "find_cpp_toolchain")
+
 _TEMPLATE = """  {{
     "directory": "OUT_DIR",
     "command": "clang++ -c {filename} -std=c++11 -Wall -Werror -I. -IBASE_DIR {system_includes}",
@@ -9,7 +11,7 @@ _TEMPLATE = """  {{
 def _compile_commands_impl(ctx):
   system_includes = " ".join([
       "-I{}".format(d)
-      for d in ctx.fragments.cpp.built_in_include_directories
+      for d in find_cpp_toolchain(ctx).built_in_include_directories
   ])
   ctx.actions.write(
       output = ctx.outputs.compile_commands,
@@ -25,9 +27,13 @@ compile_commands = rule(
             mandatory = True,
             allow_empty = False,
         ),
+        # Do not add references, temporary attribute for find_cpp_toolchain.
+        # See go/skylark-api-for-cc-toolchain for more details.
+        "_cc_toolchain": attr.label(
+            default = Label("//tools/cpp:current_cc_toolchain"),
+        ),
     },
     doc = "Generates a compile_commannds.json.in template file.",
-    fragments = ["cpp"],
     outputs = {
         "compile_commands": "compile_commands.json.in",
     },


### PR DESCRIPTION
Migrate CToolchain-dependent ctx.fragments.cpp field calls to receive the information from toolchains. This is an intermediate step in migrating to the new Skylark API for the C++ toolchain. The extra _cc_toolchain attribute will be removed later in this migration.