### PR TITLE
Add ProcessAnnotation later.

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/JavaCompilationUnitExtractor.java
@@ -710,8 +710,9 @@ public class JavaCompilationUnitExtractor {
           compiler.getTask(
               null, fileManager, diagnosticsCollector, completeOptions, null, sourceFiles);
 
-      List<Processor> procs = Lists.<Processor>newArrayList(new ProcessAnnotation(fileManager));
       ClassLoader loader = processingClassloader(classpath, processorpath);
+
+      List<Processor> procs = Lists.newArrayList();
 
       // Add any processors passed as flags.
       for (String processor : processors) {
@@ -734,6 +735,8 @@ public class JavaCompilationUnitExtractor {
           procs.add(proc);
         }
       }
+
+      procs.add(new ProcessAnnotation(fileManager));
 
       JavacTask javacTask = (JavacTask) task;
       javacTask.setProcessors(procs);


### PR DESCRIPTION
The process for gathering annotations was:
1. Add ProcessAnnotation
2. Check for anything at --processors
3. If there's nothing then check for processors exposed by META-INF

However (3) will never happen because in (1) we always add a processor. Therefore if we move (1) to happen later we have a chance of getting to annotations.

This is necessary because some processors generate source code and Kythe wasn't running those processors.