### PR TITLE
Add --experimental_strict_action_env to bazel.rc

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,2 +1,5 @@
 build --workspace_status_command tools/buildstamp/get_workspace_status
 build --auto_cpu_environment_group=//buildenv:cpu
+
+# Ensure environment variables are static across machines; allows for cross-user caching.
+build --experimental_strict_action_env


### PR DESCRIPTION
This ensures environment variables are static across machines and allows for cross-user caching.

In a Future Bazel Release, this will [become the default](https://github.com/bazelbuild/bazel/commit/9a444d4340563386b2141ab67a5bfdb14a62d311) so this keeps us ahead of the curve.