### PR TITLE
Refactor KzipReader a bit to prepare for KzipWriter

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -375,5 +375,8 @@ cc_library(
     srcs = ["libzip/error.cc"],
     hdrs = ["libzip/error.h"],
     visibility = ["//visibility:private"],
-    deps = ["@org_libzip//:zip"],
+    deps = [
+        ":status",
+        "@org_libzip//:zip",
+    ],
 )

--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -319,6 +319,7 @@ cc_library(
     deps = [
         ":index_reader",
         ":json_proto",
+        ":libzip/error",
         ":status_or",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
@@ -337,6 +338,7 @@ cc_test(
     ],
     deps = [
         ":kzip_reader",
+        ":libzip/error",
         "//third_party:gtest_main",
         # TODO(shahms): Should this go in `kzip_reader`?
         "//kythe/proto:go_cc_proto",  # Used in stringset.kzip.
@@ -366,4 +368,12 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
     ],
+)
+
+cc_library(
+    name = "libzip/error",
+    srcs = ["libzip/error.cc"],
+    hdrs = ["libzip/error.h"],
+    visibility = ["//visibility:private"],
+    deps = ["@org_libzip//:zip"],
 )

--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -120,176 +120,6 @@ StatusOr<absl::string_view> Validate(zip_t* archive) {
   return root;
 }
 
-StatusCode ZlibStatusCode(int zip_error) {
-  switch (zip_error) {
-    case ZIP_ER_OK:  // No error
-      return StatusCode::kOk;
-    case ZIP_ER_MULTIDISK:    // Multi-disk zip archives not supported
-    case ZIP_ER_COMPNOTSUPP:  // Compression method not supported
-    case ZIP_ER_ENCRNOTSUPP:  // Encryption method not supported
-    case ZIP_ER_OPNOTSUPP:    // Operation not supported
-      return StatusCode::kUnimplemented;
-    case ZIP_ER_INVAL:            // Invalid argument
-    case ZIP_ER_NOZIP:            // Not a zip archive
-    case ZIP_ER_INCONS:           // Zip archive inconsistent
-    case ZIP_ER_COMPRESSED_DATA:  // Compressed data invalid
-    case ZIP_ER_CRC:              // CRC error
-      return StatusCode::kInvalidArgument;
-    case ZIP_ER_RENAME:    // Renaming temporary file failed
-    case ZIP_ER_CLOSE:     // Closing zip archive failed
-    case ZIP_ER_SEEK:      // Seek error
-    case ZIP_ER_READ:      // Read error
-    case ZIP_ER_WRITE:     // Write error
-    case ZIP_ER_ZLIB:      // Zlib error
-    case ZIP_ER_INTERNAL:  // Internal error
-    case ZIP_ER_REMOVE:    // Can't remove file
-    case ZIP_ER_TELL:      // Tell error
-      return StatusCode::kInternal;
-    case ZIP_ER_ZIPCLOSED:  // Containing zip archive was closed
-    case ZIP_ER_INUSE:      // Resource still in use
-      return StatusCode::kFailedPrecondition;
-    case ZIP_ER_NOENT:    // No such file
-    case ZIP_ER_DELETED:  // Entry has been deleted
-      return StatusCode::kNotFound;
-    case ZIP_ER_EXISTS:  // File already exists
-      return StatusCode::kAlreadyExists;
-    case ZIP_ER_MEMORY:  // Malloc failure
-      return StatusCode::kResourceExhausted;
-    case ZIP_ER_CHANGED:  // Entry has been changed
-      return StatusCode::kAborted;
-    case ZIP_ER_EOF:  // Premature end of file
-      return StatusCode::kOutOfRange;
-    case ZIP_ER_OPEN:     // Can't open file
-    case ZIP_ER_TMPOPEN:  // Failure to create temporary file
-    default:
-      return StatusCode::kUnknown;
-  }
-}
-
-StatusCode SystemStatusCode(int sys_error) {
-  switch (sys_error) {
-    case 0:
-      return StatusCode::kOk;
-    case EINVAL:        // Invalid argument
-    case ENAMETOOLONG:  // Filename too long
-    case E2BIG:         // Argument list too long
-    case EDESTADDRREQ:  // Destination address required
-    case EDOM:          // Mathematics argument out of domain of function
-    case EFAULT:        // Bad address
-    case EILSEQ:        // Illegal byte sequence
-    case ENOPROTOOPT:   // Protocol not available
-    case ENOSTR:        // Not a STREAM
-    case ENOTSOCK:      // Not a socket
-    case ENOTTY:        // Inappropriate I/O control operation
-    case EPROTOTYPE:    // Protocol wrong type for socket
-    case ESPIPE:        // Invalid seek
-      return StatusCode::kInvalidArgument;
-    case ETIMEDOUT:  // Connection timed out
-    case ETIME:      // Timer expired
-      return StatusCode::kDeadlineExceeded;
-    case ENODEV:     // No such device
-    case ENOENT:     // No such file or directory
-    case ENOMEDIUM:  // No medium found
-    case ENXIO:      // No such device or address
-    case ESRCH:      // No such process
-      return StatusCode::kNotFound;
-    case EEXIST:         // File exists
-    case EADDRNOTAVAIL:  // Address not available
-    case EALREADY:       // Connection already in progress
-    case ENOTUNIQ:       // Name not unique on network
-      return StatusCode::kAlreadyExists;
-    case EPERM:   // Operation not permitted
-    case EACCES:  // Permission denied
-    case ENOKEY:  // Required key not available
-    case EROFS:   // Read only file system
-      return StatusCode::kPermissionDenied;
-    case ENOTEMPTY:   // Directory not empty
-    case EISDIR:      // Is a directory
-    case ENOTDIR:     // Not a directory
-    case EADDRINUSE:  // Address already in use
-    case EBADF:       // Invalid file descriptor
-    case EBADFD:      // File descriptor in bad state
-    case EBUSY:       // Device or resource busy
-    case ECHILD:      // No child processes
-    case EISCONN:     // Socket is connected
-    case EISNAM:      // Is a named type file
-    case ENOTBLK:     // Block device required
-    case ENOTCONN:    // The socket is not connected
-    case EPIPE:       // Broken pipe
-    case ESHUTDOWN:   // Cannot send after transport endpoint shutdown
-    case ETXTBSY:     // Text file busy
-    case EUNATCH:     // Protocol driver not attached
-      return StatusCode::kFailedPrecondition;
-    case ENOSPC:   // No space left on device
-    case EDQUOT:   // Disk quota exceeded
-    case EMFILE:   // Too many open files
-    case EMLINK:   // Too many links
-    case ENFILE:   // Too many open files in system
-    case ENOBUFS:  // No buffer space available
-    case ENODATA:  // No message is available on the STREAM read queue
-    case ENOMEM:   // Not enough space
-    case ENOSR:    // No STREAM resources
-    case EUSERS:   // Too many users
-      return StatusCode::kResourceExhausted;
-    case ECHRNG:     // Channel number out of range
-    case EFBIG:      // File too large
-    case EOVERFLOW:  // Value too large to be stored in data type
-    case ERANGE:     // Result too large
-      return StatusCode::kOutOfRange;
-    case ENOPKG:           // Package not installed
-    case ENOSYS:           // Function not implemented
-    case ENOTSUP:          // Operation not supported
-    case EAFNOSUPPORT:     // Address family not supported
-    case EPFNOSUPPORT:     // Protocol family not supported
-    case EPROTONOSUPPORT:  // Protocol not supported
-    case ESOCKTNOSUPPORT:  // Socket type not supported
-    case EXDEV:            // Improper link
-      return StatusCode::kUnimplemented;
-    case EAGAIN:        // Resource temporarily unavailable
-    case ECOMM:         // Communication error on send
-    case ECONNREFUSED:  // Connection refused
-    case ECONNABORTED:  // Connection aborted
-    case ECONNRESET:    // Connection reset
-    case EINTR:         // Interrupted function call
-    case EHOSTDOWN:     // Host is down
-    case EHOSTUNREACH:  // Host is unreachable
-    case ENETDOWN:      // Network is down
-    case ENETRESET:     // Connection aborted by network
-    case ENETUNREACH:   // Network unreachable
-    case ENOLCK:        // No locks available
-    case ENOLINK:       // Link has been severed
-    case ENONET:        // Machine is not on the network
-      return StatusCode::kUnavailable;
-    case EDEADLK:  // Resource deadlock avoided
-    case ESTALE:   // Stale file handle
-      return StatusCode::kAborted;
-    case ECANCELED:  // Operation cancelled
-      return StatusCode::kCancelled;
-    default:
-      return StatusCode::kUnknown;
-  }
-}
-
-StatusCode GetStatusCode(zip_error_t* error) {
-  switch (zip_error_system_type(error)) {
-    case ZIP_ET_SYS:
-      return SystemStatusCode(zip_error_code_system(error));
-    case ZIP_ET_ZLIB:
-      return ZlibStatusCode(zip_error_code_system(error));
-    case ZIP_ET_NONE:
-    default:
-      return ZlibStatusCode(zip_error_code_zip(error));
-  }
-}
-
-Status ToStatus(zip_error_t* error) {
-  StatusCode code = GetStatusCode(error);
-  if (code == StatusCode::kOk) {
-    return OkStatus();
-  }
-  return Status(code, zip_error_strerror(error));
-}
-
 absl::optional<zip_uint64_t> FileSize(zip_t* archive, zip_uint64_t index) {
   zip_stat_t sb;
   zip_stat_init(&sb);
@@ -309,12 +139,12 @@ StatusOr<std::string> ReadTextFile(zip_t* archive, const std::string& path) {
         if (zip_fread(file.get(), &result.front(), *size) == *size) {
           return result;
         } else {
-          return ToStatus(zip_file_get_error(file.get()));
+          return libzip::ToStatus(zip_file_get_error(file.get()));
         }
       }
     }
   }
-  Status status = ToStatus(zip_get_error(archive));
+  Status status = libzip::ToStatus(zip_get_error(archive));
   if (!status.ok()) {
     return status;
   }
@@ -335,7 +165,8 @@ StatusOr<IndexReader> KzipReader::Open(absl::string_view path) {
       return root.status();
     }
   }
-  return Status(ZlibStatusCode(error), absl::StrCat("Unable to open: ", path));
+  return Status(libzip::ZlibStatusCode(error),
+                absl::StrCat("Unable to open: ", path));
 }
 
 /* static */
@@ -350,7 +181,7 @@ StatusOr<IndexReader> KzipReader::FromSource(zip_source_t* source) {
       return root.status();
     }
   }
-  return ToStatus(error.get());
+  return error.ToStatus();
 }
 
 KzipReader::KzipReader(ZipHandle archive, absl::string_view root)
@@ -364,7 +195,7 @@ StatusOr<proto::IndexedCompilation> KzipReader::ReadUnit(
     ZipFileInputStream input(file.get());
     Status status = ParseFromJsonStream(&input, &unit);
     if (!status.ok()) {
-      Status zip_status = ToStatus(zip_file_get_error(file.get()));
+      Status zip_status = libzip::ToStatus(zip_file_get_error(file.get()));
       if (!zip_status.ok()) {
         // Prefer the underlying zip error, if present.
         return zip_status;
@@ -373,7 +204,7 @@ StatusOr<proto::IndexedCompilation> KzipReader::ReadUnit(
     }
     return unit;
   }
-  Status status = ToStatus(zip_get_error(archive()));
+  Status status = libzip::ToStatus(zip_get_error(archive()));
   if (!status.ok()) {
     return status;
   }

--- a/kythe/cxx/common/kzip_reader.h
+++ b/kythe/cxx/common/kzip_reader.h
@@ -32,6 +32,12 @@ class KzipReader : public IndexReaderInterface {
  public:
   static StatusOr<IndexReader> Open(absl::string_view path);
 
+  /// \brief Constructs an `IndexReader` from the provided source.
+  /// `zip_source_t` is reference counted, see
+  /// https://libzip.org/documentation/zip_source.html
+  /// for detailed ownership semantics.
+  static StatusOr<IndexReader> FromSource(zip_source_t* source);
+
   Status Scan(const ScanCallback& callback) override;
 
   StatusOr<kythe::proto::IndexedCompilation> ReadUnit(

--- a/kythe/cxx/common/libzip/error.cc
+++ b/kythe/cxx/common/libzip/error.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kythe/cxx/common/libzip/error.h"
+
+// This file intentionally left empty.

--- a/kythe/cxx/common/libzip/error.cc
+++ b/kythe/cxx/common/libzip/error.cc
@@ -16,4 +16,185 @@
 
 #include "kythe/cxx/common/libzip/error.h"
 
-// This file intentionally left empty.
+#include <errno.h>
+
+namespace kythe {
+namespace libzip {
+namespace {
+
+StatusCode SystemStatusCode(int sys_error) {
+  switch (sys_error) {
+    case 0:
+      return StatusCode::kOk;
+    case EINVAL:        // Invalid argument
+    case ENAMETOOLONG:  // Filename too long
+    case E2BIG:         // Argument list too long
+    case EDESTADDRREQ:  // Destination address required
+    case EDOM:          // Mathematics argument out of domain of function
+    case EFAULT:        // Bad address
+    case EILSEQ:        // Illegal byte sequence
+    case ENOPROTOOPT:   // Protocol not available
+    case ENOSTR:        // Not a STREAM
+    case ENOTSOCK:      // Not a socket
+    case ENOTTY:        // Inappropriate I/O control operation
+    case EPROTOTYPE:    // Protocol wrong type for socket
+    case ESPIPE:        // Invalid seek
+      return StatusCode::kInvalidArgument;
+    case ETIMEDOUT:  // Connection timed out
+    case ETIME:      // Timer expired
+      return StatusCode::kDeadlineExceeded;
+    case ENODEV:     // No such device
+    case ENOENT:     // No such file or directory
+    case ENOMEDIUM:  // No medium found
+    case ENXIO:      // No such device or address
+    case ESRCH:      // No such process
+      return StatusCode::kNotFound;
+    case EEXIST:         // File exists
+    case EADDRNOTAVAIL:  // Address not available
+    case EALREADY:       // Connection already in progress
+    case ENOTUNIQ:       // Name not unique on network
+      return StatusCode::kAlreadyExists;
+    case EPERM:   // Operation not permitted
+    case EACCES:  // Permission denied
+    case ENOKEY:  // Required key not available
+    case EROFS:   // Read only file system
+      return StatusCode::kPermissionDenied;
+    case ENOTEMPTY:   // Directory not empty
+    case EISDIR:      // Is a directory
+    case ENOTDIR:     // Not a directory
+    case EADDRINUSE:  // Address already in use
+    case EBADF:       // Invalid file descriptor
+    case EBADFD:      // File descriptor in bad state
+    case EBUSY:       // Device or resource busy
+    case ECHILD:      // No child processes
+    case EISCONN:     // Socket is connected
+    case EISNAM:      // Is a named type file
+    case ENOTBLK:     // Block device required
+    case ENOTCONN:    // The socket is not connected
+    case EPIPE:       // Broken pipe
+    case ESHUTDOWN:   // Cannot send after transport endpoint shutdown
+    case ETXTBSY:     // Text file busy
+    case EUNATCH:     // Protocol driver not attached
+      return StatusCode::kFailedPrecondition;
+    case ENOSPC:   // No space left on device
+    case EDQUOT:   // Disk quota exceeded
+    case EMFILE:   // Too many open files
+    case EMLINK:   // Too many links
+    case ENFILE:   // Too many open files in system
+    case ENOBUFS:  // No buffer space available
+    case ENODATA:  // No message is available on the STREAM read queue
+    case ENOMEM:   // Not enough space
+    case ENOSR:    // No STREAM resources
+    case EUSERS:   // Too many users
+      return StatusCode::kResourceExhausted;
+    case ECHRNG:     // Channel number out of range
+    case EFBIG:      // File too large
+    case EOVERFLOW:  // Value too large to be stored in data type
+    case ERANGE:     // Result too large
+      return StatusCode::kOutOfRange;
+    case ENOPKG:           // Package not installed
+    case ENOSYS:           // Function not implemented
+    case ENOTSUP:          // Operation not supported
+    case EAFNOSUPPORT:     // Address family not supported
+    case EPFNOSUPPORT:     // Protocol family not supported
+    case EPROTONOSUPPORT:  // Protocol not supported
+    case ESOCKTNOSUPPORT:  // Socket type not supported
+    case EXDEV:            // Improper link
+      return StatusCode::kUnimplemented;
+    case EAGAIN:        // Resource temporarily unavailable
+    case ECOMM:         // Communication error on send
+    case ECONNREFUSED:  // Connection refused
+    case ECONNABORTED:  // Connection aborted
+    case ECONNRESET:    // Connection reset
+    case EINTR:         // Interrupted function call
+    case EHOSTDOWN:     // Host is down
+    case EHOSTUNREACH:  // Host is unreachable
+    case ENETDOWN:      // Network is down
+    case ENETRESET:     // Connection aborted by network
+    case ENETUNREACH:   // Network unreachable
+    case ENOLCK:        // No locks available
+    case ENOLINK:       // Link has been severed
+    case ENONET:        // Machine is not on the network
+      return StatusCode::kUnavailable;
+    case EDEADLK:  // Resource deadlock avoided
+    case ESTALE:   // Stale file handle
+      return StatusCode::kAborted;
+    case ECANCELED:  // Operation cancelled
+      return StatusCode::kCancelled;
+    default:
+      return StatusCode::kUnknown;
+  }
+}
+
+StatusCode GetStatusCode(zip_error_t* error) {
+  switch (zip_error_system_type(error)) {
+    case ZIP_ET_SYS:
+      return SystemStatusCode(zip_error_code_system(error));
+    case ZIP_ET_ZLIB:
+      return ZlibStatusCode(zip_error_code_system(error));
+    case ZIP_ET_NONE:
+    default:
+      return ZlibStatusCode(zip_error_code_zip(error));
+  }
+}
+
+}  // namespace
+
+Status Error::ToStatus() { return kythe::libzip::ToStatus(get()); }
+
+Status ToStatus(zip_error_t* error) {
+  StatusCode code = GetStatusCode(error);
+  if (code == StatusCode::kOk) {
+    return OkStatus();
+  }
+  return Status(code, zip_error_strerror(error));
+}
+
+StatusCode ZlibStatusCode(int zip_error) {
+  switch (zip_error) {
+    case ZIP_ER_OK:  // No error
+      return StatusCode::kOk;
+    case ZIP_ER_MULTIDISK:    // Multi-disk zip archives not supported
+    case ZIP_ER_COMPNOTSUPP:  // Compression method not supported
+    case ZIP_ER_ENCRNOTSUPP:  // Encryption method not supported
+    case ZIP_ER_OPNOTSUPP:    // Operation not supported
+      return StatusCode::kUnimplemented;
+    case ZIP_ER_INVAL:            // Invalid argument
+    case ZIP_ER_NOZIP:            // Not a zip archive
+    case ZIP_ER_INCONS:           // Zip archive inconsistent
+    case ZIP_ER_COMPRESSED_DATA:  // Compressed data invalid
+    case ZIP_ER_CRC:              // CRC error
+      return StatusCode::kInvalidArgument;
+    case ZIP_ER_RENAME:    // Renaming temporary file failed
+    case ZIP_ER_CLOSE:     // Closing zip archive failed
+    case ZIP_ER_SEEK:      // Seek error
+    case ZIP_ER_READ:      // Read error
+    case ZIP_ER_WRITE:     // Write error
+    case ZIP_ER_ZLIB:      // Zlib error
+    case ZIP_ER_INTERNAL:  // Internal error
+    case ZIP_ER_REMOVE:    // Can't remove file
+    case ZIP_ER_TELL:      // Tell error
+      return StatusCode::kInternal;
+    case ZIP_ER_ZIPCLOSED:  // Containing zip archive was closed
+    case ZIP_ER_INUSE:      // Resource still in use
+      return StatusCode::kFailedPrecondition;
+    case ZIP_ER_NOENT:    // No such file
+    case ZIP_ER_DELETED:  // Entry has been deleted
+      return StatusCode::kNotFound;
+    case ZIP_ER_EXISTS:  // File already exists
+      return StatusCode::kAlreadyExists;
+    case ZIP_ER_MEMORY:  // Malloc failure
+      return StatusCode::kResourceExhausted;
+    case ZIP_ER_CHANGED:  // Entry has been changed
+      return StatusCode::kAborted;
+    case ZIP_ER_EOF:  // Premature end of file
+      return StatusCode::kOutOfRange;
+    case ZIP_ER_OPEN:     // Can't open file
+    case ZIP_ER_TMPOPEN:  // Failure to create temporary file
+    default:
+      return StatusCode::kUnknown;
+  }
+}
+
+}  // namespace libzip
+}  // namespace kythe

--- a/kythe/cxx/common/libzip/error.h
+++ b/kythe/cxx/common/libzip/error.h
@@ -19,6 +19,8 @@
 
 #include <zip.h>
 
+#include "kythe/cxx/common/status.h"
+
 namespace kythe {
 namespace libzip {
 
@@ -26,9 +28,14 @@ namespace libzip {
 class Error {
  public:
   Error() { zip_error_init(get()); }
+  ~Error() { zip_error_fini(get()); }
+
+  // Error is neither copyable nor movable.
   Error(const Error&) = delete;
   Error& operator=(const Error&) = delete;
-  ~Error() { zip_error_fini(get()); }
+
+  /// \brief Converts the Error into a Kythe::Status.
+  Status ToStatus();
 
   zip_error_t* get() { return &error_; }
 
@@ -36,6 +43,11 @@ class Error {
   zip_error_t error_;
 };
 
+/// \brief Converts a zip_error_t into kythe::Status.
+Status ToStatus(zip_error_t* error);
+
+/// \brief Translates a ZLIB_ER_* constant into a StatusCode.
+StatusCode ZlibStatusCode(int zlib_error);
 
 }  // namespace libzip
 }  // namespace kythe

--- a/kythe/cxx/common/libzip/error.h
+++ b/kythe/cxx/common/libzip/error.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KYTHE_CXX_COMMON_LIBZIP_ERROR_H_
+#define KYTHE_CXX_COMMON_LIBZIP_ERROR_H_
+
+#include <zip.h>
+
+namespace kythe {
+namespace libzip {
+
+/// \brief RAII wrapper around zip_error_t.
+class Error {
+ public:
+  Error() { zip_error_init(get()); }
+  Error(const Error&) = delete;
+  Error& operator=(const Error&) = delete;
+  ~Error() { zip_error_fini(get()); }
+
+  zip_error_t* get() { return &error_; }
+
+ private:
+  zip_error_t error_;
+};
+
+
+}  // namespace libzip
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_COMMON_LIBZIP_ERROR_H_


### PR DESCRIPTION
[Trying this again with a cleaner commit history]

This PR pulls out the zip_error_t handling a bit to prepare for sharing code with KzipWriter and exposes a FromSource factory which allows creating a KzipReader from a zip_source_t* to facilitate extension beyond local files.