### PR TITLE
RDF: Encode /kythe/code facts in Base64.

### DIFF
--- a/kythe/go/storage/tools/triples/BUILD
+++ b/kythe/go/storage/tools/triples/BUILD
@@ -16,6 +16,7 @@ go_binary(
         "//kythe/go/util/flagutil",
         "//kythe/go/util/kytheuri",
         "//kythe/go/util/schema/edges",
+        "//kythe/go/util/schema/facts",
         "//kythe/proto:storage_go_proto",
     ],
 )

--- a/kythe/go/storage/tools/triples/triples.go
+++ b/kythe/go/storage/tools/triples/triples.go
@@ -27,6 +27,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"io"
@@ -41,6 +42,7 @@ import (
 	"kythe.io/kythe/go/util/flagutil"
 	"kythe.io/kythe/go/util/kytheuri"
 	"kythe.io/kythe/go/util/schema/edges"
+	"kythe.io/kythe/go/util/schema/facts"
 
 	spb "kythe.io/kythe/proto/storage_go_proto"
 
@@ -156,6 +158,9 @@ func toTriple(entry *spb.Entry) (*rdf.Triple, error) {
 	if graphstore.IsEdge(entry) {
 		t.Predicate = entry.EdgeKind
 		t.Object = kytheuri.FromVName(entry.Target).String()
+	} else if entry.FactName == facts.Code {
+		t.Predicate = entry.FactName
+		t.Object = base64.StdEncoding.EncodeToString(entry.FactValue)
 	} else {
 		t.Predicate = entry.FactName
 		t.Object = string(entry.FactValue)


### PR DESCRIPTION
Fixes #2855. Per https://www.w3.org/TR/2014/REC-n-triples-20140225, the syntax
of N-Triples is expressed over UTF-8 encoded Unicode code points.

We are escaping code sequences correctly, but not binary values.  The
/kythe/code fact carries a wire-format protobuf message, which is not UTF-8 and
must therefore be escaped. This commit checks specifically for that fact when
encoding triples, and Base64 encodes the value. This matches the JSON encoding
for proto3 messages.