### PR TITLE
Measure bytes, not blocks, in a shell test.

### DIFF
--- a/kythe/go/platform/tools/kindex_file_generator/BUILD
+++ b/kythe/go/platform/tools/kindex_file_generator/BUILD
@@ -26,7 +26,7 @@ shell_tool_test(
       --output "$$kindex_output" \\
       --source "$$input"
 
-    size="$$(du -k "$$kindex_output" | cut -f1)"
+    size="$$(du -b "$$kindex_output" | cut -f1)"
     if [[ "$$size" -eq 0 ]] ; then
        echo "FAILED: output $$kindex_output is empty"
        exit 1


### PR DESCRIPTION
We're only concerned with whether the result is empty.
Using `-b` instead of `-k` appears to fix #2875 for
some environments.