### PR TITLE
Temporary fix for misbehaving old Clangs

### DIFF
--- a/kythe/cxx/common/status_or.h
+++ b/kythe/cxx/common/status_or.h
@@ -59,8 +59,18 @@ class ABSL_MUST_USE_RESULT StatusOr final {
   StatusOr& operator=(StatusOr<U>&& other);
 
   ABSL_MUST_USE_RESULT bool ok() const { return this->status_.ok(); }
-  const Status& status() const& { return this->status_; }
+
+#if defined(__clang__) && __clang_major__ == 3 && __clang_minor__ == 5
+  // clang 3.5 will choose the incorrect overload if the ref-qualifiers
+  // are present.
+  // TODO: either bump the minimum version of clang we require or find a
+  // reasonable fix for this.
+  const Status& status() const { return this->status_; }
+  Status status() { return std::move(this->status_); }
+#else
+  const Status& status() const & { return this->status_; }
   Status status() && { return std::move(this->status_); }
+#endif
 
   explicit operator bool() const { return this->ok(); }
 


### PR DESCRIPTION
This should partially address 2873 and help us to get our
buildbots green again. We shouldn't consider the issue closed
until we fix the issue permanently (likely by requiring
a newer clang).