### PR TITLE
Factor out common test-source-root routine

### DIFF
--- a/kythe/cxx/common/BUILD
+++ b/kythe/cxx/common/BUILD
@@ -338,6 +338,7 @@ cc_test(
         "//kythe/cxx/common/testdata:stringset.kzip",
     ],
     deps = [
+        ":testutil",
         ":kzip_reader",
         ":libzip/error",
         "//third_party:gtest_main",
@@ -372,6 +373,7 @@ cc_test(
         ":kzip_reader",
         ":kzip_writer",
         ":libzip/error",
+        ":testutil",
         "//kythe/proto:go_cc_proto",  # Used in stringset.kzip.
         "//third_party:gtest_main",
         "@com_google_absl//absl/strings",
@@ -411,5 +413,16 @@ cc_library(
     deps = [
         ":status",
         "@org_libzip//:zip",
+    ],
+)
+
+cc_library(
+    name = "testutil",
+    testonly = 1,
+    srcs = ["testutil.cc"],
+    hdrs = ["testutil.h"],
+    deps = [
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/strings",
     ],
 )

--- a/kythe/cxx/common/kzip_writer_test.cc
+++ b/kythe/cxx/common/kzip_writer_test.cc
@@ -17,6 +17,7 @@
 #include "kythe/cxx/common/kzip_writer.h"
 
 #include <zip.h>
+#include <cstdlib>
 
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -25,26 +26,17 @@
 #include "gtest/gtest.h"
 #include "kythe/cxx/common/kzip_reader.h"
 #include "kythe/cxx/common/libzip/error.h"
+#include "kythe/cxx/common/testutil.h"
 
 namespace kythe {
 namespace {
 
-std::string TestRoot() {
-  if (auto* workspace = getenv("TEST_WORKSPACE")) {
-    return absl::StrCat(
-        absl::StripSuffix(CHECK_NOTNULL(getenv("TEST_SRCDIR")), "/"), "/",
-        absl::StripSuffix(workspace, "/"), "/");
-  }
-  static char path[PATH_MAX];
-  return absl::StrCat(absl::StripSuffix(getcwd(path, PATH_MAX), "/"), "/");
-}
-
 absl::string_view TestTmpdir() {
-  return absl::StripSuffix(CHECK_NOTNULL(getenv("TEST_TMPDIR")), "/");
+  return absl::StripSuffix(std::getenv("TEST_TMPDIR"), "/");
 }
 
 std::string TestFile(absl::string_view basename) {
-  return absl::StrCat(TestRoot(), "kythe/cxx/common/testdata/",
+  return absl::StrCat(TestSourceRoot(), "kythe/cxx/common/testdata/",
                       absl::StripPrefix(basename, "/"));
 }
 

--- a/kythe/cxx/common/testutil.cc
+++ b/kythe/cxx/common/testutil.cc
@@ -26,6 +26,8 @@
 namespace kythe {
 namespace {
 
+// This must match the name from the workspace(name={name})
+// rule in the root WORKSPACE file.
 constexpr char kDefaultWorkspace[] = "io_kythe";
 
 }  // namespace

--- a/kythe/cxx/common/testutil.cc
+++ b/kythe/cxx/common/testutil.cc
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "kythe/cxx/common/testutil.h"
+
+#include <unistd.h>
+#include <cstdlib>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+#include "glog/logging.h"
+
+namespace kythe {
+namespace {
+
+constexpr char kDefaultWorkspace[] = "io_kythe";
+
+}  // namespace
+
+std::string TestSourceRoot() {
+  const auto* workspace = std::getenv("TEST_WORKSPACE");
+  if (workspace == nullptr) {
+    workspace = kDefaultWorkspace;
+  }
+  return absl::StrCat(
+      absl::StripSuffix(CHECK_NOTNULL(std::getenv("TEST_SRCDIR")), "/"), "/",
+      absl::StripSuffix(workspace, "/"), "/");
+}
+
+}  // namespace kythe

--- a/kythe/cxx/common/testutil.h
+++ b/kythe/cxx/common/testutil.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef KYTHE_CXX_COMMON_TESTUTIL_H_
+#define KYTHE_CXX_COMMON_TESTUTIL_H_
+
+#include <string>
+
+namespace kythe {
+
+/// \brief Returns the path relative to which test files may be found.
+/// That path will always end in a "/".
+std::string TestSourceRoot();
+
+}  // namespace kythe
+
+#endif  // KYTHE_CXX_COMMON_TESTUTIL_H_


### PR DESCRIPTION
This should further facilitate more reliable imports.