### PR TITLE
Don't use std::move for the clang-3.5 ref-qualifier workaround

### DIFF
--- a/kythe/cxx/common/status_or.h
+++ b/kythe/cxx/common/status_or.h
@@ -66,7 +66,7 @@ class ABSL_MUST_USE_RESULT StatusOr final {
   // TODO: either bump the minimum version of clang we require or find a
   // reasonable fix for this.
   const Status& status() const { return this->status_; }
-  Status status() { return std::move(this->status_); }
+  Status status() { return this->status_; }
 #else
   const Status& status() const & { return this->status_; }
   Status status() && { return std::move(this->status_); }


### PR DESCRIPTION
When not using ref-qualifiers on the member functions, returning a value by-move has potentially confusing semantics so switch to using a copy.