### PR TITLE
Java indexer: ignore final modifiers on enums

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -323,6 +323,11 @@ public class JavaEntrySets extends KytheEntrySets {
     hashes.add(sym.getQualifiedName().toString().hashCode());
     hashes.add(sym.getKind().ordinal());
     for (Modifier mod : sym.getModifiers()) {
+      if (Modifier.FINAL == mod && sym.getKind() == ElementKind.ENUM) {
+        // Ignored due to Bazel's headers always making enums final.  See:
+        // https://github.com/google/turbine/blob/0536e276/java/com/google/turbine/binder/CompUnitPreprocessor.java#L168
+        continue;
+      }
       hashes.add(mod.ordinal());
     }
 


### PR DESCRIPTION
Bazel's --java_header_compilation flag always tags enums as final which will cause the analyzer to assign different VNames to the definition of the Symbol and references to the Symbol outside of the defining compilation.  To compensate, we just ignore that modifier while constructing VNames for enums.

See: https://github.com/google/turbine/blob/0536e276/java/com/google/turbine/binder/CompUnitPreprocessor.java#L168