### PR TITLE
Add minimal reproduction for #2899

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -810,6 +810,16 @@ cc_indexer_test(
     ],
 )
 
+cc_indexer_test(
+    name = "macros_lambda_call",
+    srcs = ["basic/macros_lambda_call.cc"],
+    ignore_dups = True,
+    tags = [
+        "basic",
+        "manual",  # https://github.com/google/kythe/issues/2899
+    ],
+)
+
 test_suite(
     name = "indexer_basic",
     tags = ["basic"],

--- a/kythe/cxx/indexer/cxx/testdata/basic/macros_lambda_call.cc
+++ b/kythe/cxx/indexer/cxx/testdata/basic/macros_lambda_call.cc
@@ -1,0 +1,12 @@
+#define CHECK(x) (x)
+
+//- @Call defines/binding CallDecl
+void Call();
+
+void fn() {
+  CHECK([] {
+    //- @Call ref CallDecl
+    //- @"Call()" ref/call CallDecl
+    Call();
+  });
+}


### PR DESCRIPTION
Adds a disabled test case for mis-anchored ref/call edges nested in macros nested in lambdas. Regular `ref` is accurate, but `ref/call` points to the start of the macro invocation.