### PR TITLE
Add package extutil, to bridge .kzip/.kindex output.

### DIFF
--- a/kythe/go/extractors/bazel/extutil/BUILD
+++ b/kythe/go/extractors/bazel/extutil/BUILD
@@ -1,0 +1,16 @@
+load("//tools:build_rules/shims.bzl", "go_library")
+
+package(default_visibility = ["//kythe:default_visibility"])
+
+# A library to support Bazel extractors switching between .kzip and .kindex
+# output, for temporary use in migrating away from .kindex files.
+go_library(
+    name = "extutil",
+    srcs = ["extutil.go"],
+    deps = [
+        "//kythe/go/extractors/bazel",
+        "//kythe/go/platform/kindex",
+        "//kythe/go/platform/kzip",
+        "//third_party/bazel:extra_actions_base_go_proto",
+    ],
+)

--- a/kythe/go/extractors/bazel/extutil/extutil.go
+++ b/kythe/go/extractors/bazel/extutil/extutil.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 The Kythe Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package extutil implements shared code for extracting and writing output
+// from Bazel actions, either to .kindex or a .kzip files. This is a temporary
+// measure to support migrating to .kzip output.
+package extutil
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"kythe.io/kythe/go/extractors/bazel"
+)
+
+// ExtractAndWrite extracts a spawn action through c and writes the results to
+// the specified output file. The output format is based on the file extension:
+//
+//   .kindex   -- writes a kindex file
+//   .kzip     -- writes a kzip file
+//   otherwise -- reports an error
+//
+func ExtractAndWrite(ctx context.Context, c *bazel.Config, ai *bazel.ActionInfo, outputPath string) error {
+	switch ext := filepath.Ext(outputPath); ext {
+	case ".kindex":
+		cu, err := c.Extract(ctx, ai)
+		if err != nil {
+			return fmt.Errorf("extracting: %v", err)
+		}
+		if err := bazel.Write(cu, outputPath); err != nil {
+			return fmt.Errorf("writing kindex: %v", err)
+		}
+
+	case ".kzip":
+		w, err := bazel.NewKZIP(outputPath)
+		if err != nil {
+			return fmt.Errorf("creating kzip writer: %v", err)
+		}
+		if _, err := c.ExtractToFile(ctx, ai, w); err != nil {
+			return fmt.Errorf("extracting: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("closing output: %v", err)
+		}
+
+	default:
+		return fmt.Errorf("unknown output extension %q", ext)
+	}
+	return nil
+}


### PR DESCRIPTION
In support of #2864, add a library to make it easier for extractors that
currently emit .kindex files to switch between that and .kzip format.  This
will allow an extractor to emit either format until we are finished with the
.kindex migration, at which point this can be collapsed and removed.