### PR TITLE
Bazel extractors: Update dependencies, support code.

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/BUILD
@@ -7,6 +7,7 @@ go_binary(
     srcs = ["bazel_go_extractor.go"],
     deps = [
         "//kythe/go/extractors/bazel",
+        "//kythe/go/extractors/bazel/extutil",
         "//kythe/go/extractors/golang",
         "//kythe/go/extractors/govname",
         "//kythe/go/util/vnameutil",

--- a/kythe/go/extractors/cmd/bazel/extract_kindex/BUILD
+++ b/kythe/go/extractors/cmd/bazel/extract_kindex/BUILD
@@ -7,6 +7,7 @@ go_binary(
     srcs = ["extract_kindex.go"],
     deps = [
         "//kythe/go/extractors/bazel",
+        "//kythe/go/extractors/bazel/extutil",
         "//kythe/go/platform/kindex",
         "//kythe/go/util/vnameutil",
         "//third_party/bazel:extra_actions_base_go_proto",


### PR DESCRIPTION
Consolidate places where library code was duplicated in the extractor binaries.
There are no functional changes here. This cleanup is preparatory to a solution
for #2912, but for the moment that bug is still active.