### PR TITLE
Bazel Go extractor: Ensure compilations are tagged for "go".

### DIFF
--- a/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
+++ b/kythe/go/extractors/cmd/bazel/bazel_go_extractor/bazel_go_extractor.go
@@ -157,6 +157,7 @@ func (*extractor) checkEnv(name, _ string) bool { return name != "PATH" }
 func (e *extractor) fixup(unit *apb.CompilationUnit) error {
 	// Try to infer a unit vname from the output.
 	if vname, ok := e.rules.Apply(e.compileArgs.outputPath); ok {
+		vname.Language = govname.Language
 		unit.VName = vname
 	}
 	return bazel.AddDetail(unit, &gopb.GoDetails{


### PR DESCRIPTION
The extractor defaults all compilations to the "go" language, but inference
based on filenames omits a language label (correctly, per the schema). In the
cases where we use that inference, ensure the language remains set.