### PR TITLE
Re-work the genyacc macro.

### DIFF
--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -4,14 +4,14 @@ load("//tools:build_rules/lexyacc.bzl", "genlex", "genyacc")
 
 genyacc(
     name = "parser",
-    srcs = ["assertions.yy"],
-    outs = [
-        "parser.yy.cc",
-        "parser.yy.hh",
+    src = "assertions.yy",
+    extra_outs = [
         "location.hh",
         "stack.hh",
         "position.hh",
     ],
+    header_out = "parser.yy.hh",
+    source_out = "parser.yy.cc",
 )
 
 genlex(

--- a/tools/build_rules/lexyacc.bzl
+++ b/tools/build_rules/lexyacc.bzl
@@ -1,18 +1,27 @@
 # The 0th src of genlex must be the lexer input.
 def genlex(name, srcs, out):
-  cmd = "flex -o $(@D)/%s $(location %s)" % (out, srcs[0])
-  native.genrule(
-    name = name,
-    outs = [out],
-    srcs = srcs,
-    cmd = cmd
-  )
+    cmd = "flex -o $(@D)/%s $(location %s)" % (out, srcs[0])
+    native.genrule(
+        name = name,
+        outs = [out],
+        srcs = srcs,
+        cmd = cmd,
+    )
 
-def genyacc(name, srcs, outs):
-  cmd = "bison -o $(@D)/%s $(location %s)" % (outs[0], srcs[0])
-  native.genrule(
-    name = name,
-    outs = outs,
-    srcs = srcs,
-    cmd = cmd
-  )
+def genyacc(name, src, header_out, source_out, extra_outs = []):
+    """Generate a C++ parser from a Yacc file using Bison.
+
+    Args:
+      name: The name of the rule.
+      src: The input grammar file.
+      header_out: The generated header file.
+      source_out: The generated source file.
+      extra_outs: Additional generated outputs.
+    """
+    cmd = "bison -o $(@D)/%s $(location %s)" % (source_out, src)
+    native.genrule(
+        name = name,
+        outs = [source_out, header_out] + extra_outs,
+        srcs = [src],
+        cmd = cmd,
+    )


### PR DESCRIPTION
Rather than requiring the srcs and outputs to have a certain order, make
explicit the (one) grammar-file input, the header and source outputs, and
additional outputs generated by the compiler-compiler. Also, while I'm in here,
add some documentation.