### PR TITLE
kzip doc: Clarify the computation of unit digests.

### DIFF
--- a/kythe/docs/kythe-kzip.txt
+++ b/kythe/docs/kythe-kzip.txt
@@ -84,7 +84,9 @@ subdirectories, one named `units` and one named `files`.
 A *unit file* is a file containing a compilation unit description.  The name of
 a unit file is computed by digesting the compilation unit with SHA256, and
 encoding the resulting hash as a string of lowercase ASCII hexadecimal
-digits. This string becomes the filename of the unit file.
+digits. This string becomes the filename of the unit file. Note that the digest
+should only process the CompilationUnit itself, and should not include the
+other contents of the wrapper message.
 
 A *data file* is a file containing an unstructured blob of raw (uncompressed)
 file data.  The name name of a data file is computed by hashing the file


### PR DESCRIPTION
The spec says that the digest should only apply to the CompilationUnit itself,
not its wrapper message, but this was a little subtle and could easily be
overlooked. Make it more explicit.