### PR TITLE
Re-work the genlex macro.

### DIFF
--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -16,11 +16,9 @@ genyacc(
 
 genlex(
     name = "lexer",
-    srcs = [
-        "assertions.lex",
-        ":parser",
-    ],
+    src = "assertions.lex",
     out = "lexer.yy.cc",
+    includes = [":parser"],
 )
 
 cc_library(

--- a/tools/build_rules/lexyacc.bzl
+++ b/tools/build_rules/lexyacc.bzl
@@ -1,10 +1,17 @@
-# The 0th src of genlex must be the lexer input.
-def genlex(name, srcs, out):
-    cmd = "flex -o $(@D)/%s $(location %s)" % (out, srcs[0])
+def genlex(name, src, out, includes = []):
+    """Generate a C++ lexer from a lex file using Flex.
+
+    Args:
+      name: The name of the rule.
+      src: The .lex source file.
+      out: The generated source file.
+      includes: A list of headers included by the .lex file.
+    """
+    cmd = "flex -o $(@D)/%s $(location %s)" % (out, src)
     native.genrule(
         name = name,
         outs = [out],
-        srcs = srcs,
+        srcs = [src] + includes,
         cmd = cmd,
     )
 


### PR DESCRIPTION
Rather than requiring the srcs have a certain order, make explicit the (one)
grammar-file input, and separate includes. Also, while I'm in here, add some
documentation.