### PR TITLE
KLS: Deal more gracefully with zero-width definition spans.

### DIFF
--- a/kythe/go/languageserver/languageserver.go
+++ b/kythe/go/languageserver/languageserver.go
@@ -441,18 +441,21 @@ func (ls *Server) anchorToLoc(w Workspace, a *xpb.Anchor) *lsp.Location {
 }
 
 func spanToRange(s *cpb.Span) *lsp.Range {
-	if s == nil || s.Start == nil || s.End == nil {
+	if s == nil || s.Start == nil {
 		return nil
+	} else if s.End == nil {
+		s.End = s.Start
 	}
 
-	// LineNumber is 1 indexed, so 0 indicates unknown which
-	// means it can't be used for lookups so we discard
+	// LineNumber is 1 indexed, so 0 indicates it's unknown, which in turn
+	// means it can't be used for lookups so we discard these.
 	if s.Start.LineNumber == 0 || s.End.LineNumber == 0 {
 		return nil
 	}
 
 	return &lsp.Range{
 		Start: lsp.Position{
+			// N.B. LSP line numbers are 0-based, Kythe is 1-based.
 			Line:      int(s.Start.LineNumber - 1),
 			Character: int(s.Start.ColumnOffset),
 		},

--- a/kythe/go/languageserver/languageserver_test.go
+++ b/kythe/go/languageserver/languageserver_test.go
@@ -79,7 +79,7 @@ func (c MockClient) Nodes(_ context.Context, x *gpb.NodesRequest) (*gpb.NodesRep
 	return nil, fmt.Errorf("not Implemented")
 }
 func TestReferences(t *testing.T) {
-	const sourceText = "hi\nthere\nhi"
+	const sourceText = "hi\nthere\nhi\nend"
 	c := MockClient{
 		decRsp: []mockDec{
 			{
@@ -93,6 +93,11 @@ func TestReferences(t *testing.T) {
 							Span: &cpb.Span{
 								Start: &cpb.Point{LineNumber: 3, ColumnOffset: 0},
 								End:   &cpb.Point{LineNumber: 3, ColumnOffset: 2}}},
+						"kythe://corpus?path=file.txt#alt": {
+							Ticket: "kythe://corpus?path=file.txt#alt",
+							Parent: "kythe://corpus?path=file.txt",
+							Span: &cpb.Span{
+								Start: &cpb.Point{LineNumber: 4}}},
 					},
 					Reference: []*xpb.DecorationsReply_Reference{
 						{
@@ -108,7 +113,14 @@ func TestReferences(t *testing.T) {
 							Span: &cpb.Span{
 								Start: &cpb.Point{LineNumber: 3, ColumnOffset: 0},
 								End:   &cpb.Point{LineNumber: 3, ColumnOffset: 2}},
-						}}}}},
+						},
+						{
+							TargetDefinition: "kythe://corpus?path=file.txt#end",
+							TargetTicket:     "kythe://corpus?path=file.txt#alt",
+							Span: &cpb.Span{
+								Start: &cpb.Point{LineNumber: 4}},
+						},
+					}}}},
 		refRsp: []mockRef{
 			{
 				ticket: "kythe://corpus?path=file.txt#hi",
@@ -123,7 +135,20 @@ func TestReferences(t *testing.T) {
 										Parent: "kythe://corpus?path=file.txt",
 										Span: &cpb.Span{
 											Start: &cpb.Point{LineNumber: 3, ColumnOffset: 0},
-											End:   &cpb.Point{LineNumber: 3, ColumnOffset: 2}}}}}}}}}},
+											End:   &cpb.Point{LineNumber: 3, ColumnOffset: 2},
+										},
+									},
+								},
+								{
+									Anchor: &xpb.Anchor{
+										Ticket: "kythe://corpus?path=file.txt#end",
+										Parent: "kythe://corpus?path=file.txt",
+										Span: &cpb.Span{
+											Start: &cpb.Point{LineNumber: 4},
+										},
+									},
+								},
+							}}}}}},
 		docRsp: []mockDoc{{
 			ticket: "kythe://corpus?path=file.txt#hi",
 			resp: xpb.DocumentationReply{
@@ -200,7 +225,15 @@ func TestReferences(t *testing.T) {
 		URI: "file:///root/dir/file.txt",
 		Range: lsp.Range{
 			Start: lsp.Position{Line: 6, Character: 0},
-			End:   lsp.Position{Line: 6, Character: 2}}}}
+			End:   lsp.Position{Line: 6, Character: 2},
+		},
+	}, {
+		URI: "file:///root/dir/file.txt",
+		Range: lsp.Range{
+			Start: lsp.Position{Line: 7},
+			End:   lsp.Position{Line: 7},
+		},
+	}}
 
 	if err := testutil.DeepEqual(locs, expected); err != nil {
 		t.Errorf("Incorrect references returned\n  Expected: %#v\n  Found:    %#v", expected, locs)


### PR DESCRIPTION
If an indexer emits a zero-width span by providing a start location without an
end, the language server will currently discard it because it lacks an end
marker. While this is not an ideal way for the indexer to represent
definitions, we can get a somewhat less surprising result by reusing the start
location as the end when the latter wasn't provided.