### PR TITLE
KLS: Don't discard an unresolved empty location during remapping.

### DIFF
--- a/kythe/go/languageserver/languageserver.go
+++ b/kythe/go/languageserver/languageserver.go
@@ -307,12 +307,13 @@ func (ls *Server) TextDocumentDefinition(params lsp.TextDocumentPositionParams) 
 				return []lsp.Location{loc}, nil
 			}
 
-			// There definition range doesn't exist anymore
-			return []lsp.Location{}, nil
+			// Their definition range doesn't exist anymore, or is empty.  If
+			// it's empty fall through and return the original location Kythe
+			// reported.
+			if l.Range.Start != l.Range.End {
+				return []lsp.Location{}, nil
+			}
 		}
-
-		log.Printf("Unable to map definition to local location")
-		// We don't how to map it so we just return the location from Kythe
 		return []lsp.Location{*l}, nil
 	}
 


### PR DESCRIPTION
This is a follow-up to #2944. In addition to not throwing away empty spans from
the service, also ensure that when those spans are not discarded when they
don't get moved by remapping.