### PR TITLE
Link against JDK8 targeted langtools

### DIFF
--- a/third_party/javac/BUILD
+++ b/third_party/javac/BUILD
@@ -9,10 +9,7 @@ filegroup(
 
 java_import(
     name = "javac",
-    jars = [
-        "jdk_compiler.jar",
-        "java_compiler.jar",
-    ],
+    jars = ["javac-9-dev-r4023-1.jar"],
 )
 
 filegroup(


### PR DESCRIPTION
This is a partial rollback of #2892 to ensure the Java indexer/extractor can on JRE8.