### PR TITLE
Unbreak verifier on macOsX

### DIFF
--- a/kythe/cxx/verifier/assertions.yy
+++ b/kythe/cxx/verifier/assertions.yy
@@ -1,8 +1,9 @@
 // Started from the calc++ example code as part of the Bison-3.0 distribution.
+// NOTE: This file must remain compatible with Bison 2.3.
 %skeleton "lalr1.cc"
 %defines
-%define parser_class_name {AssertionParserImpl}
-%code requires {
+%define "parser_class_name" "AssertionParserImpl"
+%{
 /*
  * Copyright 2014 The Kythe Authors. All rights reserved.
  *
@@ -29,7 +30,7 @@ namespace verifier {
 class AssertionParser;
 }
 }
-}
+%}
 %parse-param { ::kythe::verifier::AssertionParser &context }
 %lex-param { ::kythe::verifier::AssertionParser &context }
 %locations

--- a/kythe/web/site/getting-started.md
+++ b/kythe/web/site/getting-started.md
@@ -42,7 +42,7 @@ Kythe relies on the following external dependencies:
 * libcurl4-openssl-dev
 * uuid-dev
 * libssl-dev
-* bison-3.0.4
+* bison-3.0.4 (2.3 is also acceptable)
 * flex-2.5
 * [docker](https://www.docker.com/) (for release images `//kythe/release/...` and `//buildtools/docker`)
 * [leiningen](http://leiningen.org/) (used to build `kythe/web/ui`)

--- a/tools/build_rules/lexyacc.bzl
+++ b/tools/build_rules/lexyacc.bzl
@@ -25,7 +25,8 @@ def genyacc(name, src, header_out, source_out, extra_outs = []):
       source_out: The generated source file.
       extra_outs: Additional generated outputs.
     """
-    cmd = "bison -o $(@D)/%s $(location %s)" % (source_out, src)
+    arg_adjust = "$$(bison --version | grep -qE '^bison .* 3\..*' && echo -Wno-deprecated)"
+    cmd = "bison %s -o $(@D)/%s $(location %s)" % (arg_adjust, source_out, src)
     native.genrule(
         name = name,
         outs = [source_out, header_out] + extra_outs,


### PR DESCRIPTION
Support ancient Bison again. Fixes #2943.

Please check that this doesn't also upset Linux (I have limited access to that environment just this moment)