### PR TITLE
Remove deprecated use of built-in http/git rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "io_kythe")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("//:version.bzl", "check_version")
 
 # Check that the user has a version between our minimum supported version of


### PR DESCRIPTION
The built-in http and git rules are being deprecated in favour of the
starlark versions so load them from their respective starlark modules.

Tested using `--incompatible_remove_native_git_repository` and
`--incompatible_remove_native_http_archive` flags.

See https://groups.google.com/forum/#!topic/bazel-discuss/dO2MHQLwJF0