### PR TITLE
Use our shasum tool instead of md5 for releases

### DIFF
--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -100,6 +100,9 @@ sh_test(
         "//third_party/guava",
         "@com_github_stedolan_jq//:jq",
     ],
+    # Since go binaries are not located at their bazel target path (//go/binary
+    # might be in bazel-out/go/binary/host/text/binary), pass the actual
+    # location of the binary directly to the shell script.
     args = ["$(location //kythe/go/platform/tools/shasum_tool)"],
     tags = [
         "local",

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -45,12 +45,14 @@ genrule(
     ],
     outs = [
         "kythe-" + release_version + ".tar.gz",
-        "kythe-" + release_version + ".tar.gz.md5",
+        "kythe-" + release_version + ".tar.gz.sha256",
     ],
     cmd = " ".join([
         "export GENDIR=$(GENDIR);",
         "export BINDIR=$(BINDIR);",
-        "$(location package_release.sh) $(location kythe-" + release_version + ".tar.gz)",
+        "$(location package_release.sh)",
+        "$(location //kythe/go/platform/tools/shasum_tool)",
+        "$(location kythe-" + release_version + ".tar.gz)",
         "$(locations misc)",
         "--cp $(location java_indexer) indexers/java_indexer.jar",
         "--cp $(location jvm_indexer) indexers/jvm_indexer.jar",
@@ -71,7 +73,10 @@ genrule(
     ]),
     heuristic_label_expansion = False,
     tags = ["manual"],
-    tools = ["package_release.sh"],
+    tools = [
+        "package_release.sh",
+        "//kythe/go/platform/tools/shasum_tool"
+    ],
 )
 
 filegroup(
@@ -89,11 +94,13 @@ sh_test(
     srcs = ["release_test.sh"],
     data = [
         ":release",
+        "//kythe/go/platform/tools/shasum_tool",
         "//kythe/testdata:entries",
         "//kythe/testdata:test.kindex",
         "//third_party/guava",
         "@com_github_stedolan_jq//:jq",
     ],
+    args = ["$(location //kythe/go/platform/tools/shasum_tool)"],
     tags = [
         "local",
         "manual",

--- a/kythe/release/package_release.sh
+++ b/kythe/release/package_release.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script to package a release tar and create its associated .md5 checksum.
+# Script to package a release tar and create its associated .sha256 checksum.
 #
-# Usage: package_release.sh <path-to-output-tar.gz> [package contents]
+# Usage: package_release.sh <shasum_tool> <path-to-output-tar.gz> [package contents]
 #
 # In the simplest case, each file given will be placed in the root of the
 # resulting archive.  The --relpath, --path, and --cp flags change this behavior
@@ -33,7 +33,7 @@
 #
 # Example:
 #   BINDIR=bazel-bin/ \
-#     package_release.sh /tmp/b.tar.gz README.adoc LICENSE \
+#     package_release.sh /path/to/sha /tmp/b.tar.gz README.adoc LICENSE \
 #       --path some/path/for/docs kythe/docs/kythe-{overview,storage}.txt \
 #       --relpaths kythe/docs bazel-bin/kythe/docs/schema/schema.html \
 #       --cp CONTRIBUTING.md kythe/docs/how-to-contribute.md
@@ -46,6 +46,9 @@
 #       kythe-storage.txt
 #       schema.html
 #       how-to-contribute.md
+
+SHASUM_TOOL="$1"
+shift
 
 OUT="$1"
 shift
@@ -117,5 +120,4 @@ done
 
 tar czf "$OUT" -C "$OUT.dir" .
 
-cd "$(dirname "$OUT")"
-md5sum "$(basename "$OUT")" > "$(basename "$OUT").md5"
+$SHASUM_TOOL "$OUT" > "$OUT.sha256"

--- a/kythe/release/release_test.sh
+++ b/kythe/release/release_test.sh
@@ -18,6 +18,8 @@ set -o pipefail
 # Test the Kythe release package for basic functionality.
 
 export TMPDIR=${TEST_TMPDIR:?}
+SHASUM_TOOL="$PWD/$1"
+shift
 
 TEST_PORT=9898
 ADDR=localhost:$TEST_PORT
@@ -32,7 +34,12 @@ fi
 
 cd kythe/release
 
-md5sum -c kythe-*.tar.gz.md5
+EXPECTED_SUM=$(cat kythe-*.tar.gz.sha256)
+SUM=$("$SHASUM_TOOL" kythe-*.tar.gz)
+if [[ "$SUM" != "$EXPECTED_SUM" ]]; then
+  echo "Expected digest \"$EXPECTED_SUM\" but got \"$SUM\"."
+  exit 1
+fi
 
 rm -rf "$TMPDIR/release"
 mkdir "$TMPDIR/release"

--- a/kythe/release/setup_release.sh
+++ b/kythe/release/setup_release.sh
@@ -28,7 +28,7 @@
 #   4) "Draft a new release" at https://github.com/google/kythe/releases
 #   5) Set tag version / release title to the new $VERSION
 #   6) Set description to newest section of RELEASES.md
-#   7) Upload bazel-genfiles/kythe/release/kythe-$VERSION.tar.gz{,.md5}
+#   7) Upload bazel-genfiles/kythe/release/kythe-$VERSION.tar.gz{,.sha256}
 #      These files were generated in step 3.
 #   8) Mark as "pre-release" and "Save draft"
 #   9) Add draft release URL to Pull Request


### PR DESCRIPTION
md5 is not in the normal mac PATH, so it is easier if we just use a signature
generated from our own shasum tool.

This is necessary now since we are setting
experimental_strict_action_env in our bazel.rc.