### PR TITLE
Use wc -c instead of du -b

### DIFF
--- a/kythe/go/platform/tools/kindex_file_generator/BUILD
+++ b/kythe/go/platform/tools/kindex_file_generator/BUILD
@@ -26,7 +26,7 @@ shell_tool_test(
       --output "$$kindex_output" \\
       --source "$$input"
 
-    size="$$(du -b "$$kindex_output" | cut -f1)"
+    size="$$(wc -c < "$$kindex_output")"
     if [[ "$$size" -eq 0 ]] ; then
        echo "FAILED: output $$kindex_output is empty"
        exit 1

--- a/kythe/go/platform/tools/kindex_file_generator/BUILD
+++ b/kythe/go/platform/tools/kindex_file_generator/BUILD
@@ -26,8 +26,7 @@ shell_tool_test(
       --output "$$kindex_output" \\
       --source "$$input"
 
-    size="$$(wc -c < "$$kindex_output")"
-    if [[ "$$size" -eq 0 ]] ; then
+    if [[ ! -s "$$kindex_output" ]]; then
        echo "FAILED: output $$kindex_output is empty"
        exit 1
     fi


### PR DESCRIPTION
du -b doesn't exist on macOS. We can use wc -c instead to get the character count.