### PR TITLE
Fix Go protobuf link warnings

### DIFF
--- a/kythe/go/extractors/config/BUILD
+++ b/kythe/go/extractors/config/BUILD
@@ -11,7 +11,7 @@ go_library(
     deps = [
         "//kythe/go/extractors/config/default/mvn",
         "//kythe/proto:extraction_config_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@org_bitbucket_creachadair_shell//:go_default_library",
     ],
@@ -25,7 +25,7 @@ go_test(
     deps = [
         "//kythe/go/test/testutil",
         "//kythe/proto:extraction_config_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/languageserver/BUILD
+++ b/kythe/go/languageserver/BUILD
@@ -31,7 +31,7 @@ go_library(
         "//kythe/proto:common_go_proto",
         "//kythe/proto:graph_go_proto",
         "//kythe/proto:xref_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_sergi_go_diff//diffmatchpatch:go_default_library",
         "@com_github_sourcegraph_go_langserver//pkg/lsp:go_default_library",

--- a/kythe/go/platform/indexpack/BUILD
+++ b/kythe/go/platform/indexpack/BUILD
@@ -9,7 +9,7 @@ go_library(
         "//kythe/go/platform/analysis",
         "//kythe/go/platform/vfs",
         "//kythe/go/platform/vfs/zip",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
     ],

--- a/kythe/go/platform/kcd/kythe/BUILD
+++ b/kythe/go/platform/kcd/kythe/BUILD
@@ -11,7 +11,7 @@ go_library(
         "//kythe/proto:analysis_go_proto",
         "//kythe/proto:buildinfo_go_proto",
         "//kythe/proto:storage_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/platform/kzip/BUILD
+++ b/kythe/go/platform/kzip/BUILD
@@ -12,7 +12,7 @@ go_library(
         "//kythe/proto:cxx_go_proto",
         "//kythe/proto:go_go_proto",
         "//kythe/proto:java_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
     ],
 )
 

--- a/kythe/go/platform/tools/pack2kzip/BUILD
+++ b/kythe/go/platform/tools/pack2kzip/BUILD
@@ -10,7 +10,7 @@ go_binary(
         "//kythe/go/platform/kcd/kythe",
         "//kythe/go/platform/kzip",
         "//kythe/proto:analysis_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@org_bitbucket_creachadair_stringset//:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
         "@org_golang_x_sync//semaphore:go_default_library",

--- a/kythe/go/platform/tools/viewindex/BUILD
+++ b/kythe/go/platform/tools/viewindex/BUILD
@@ -14,6 +14,6 @@ go_binary(
         "//kythe/proto:cxx_go_proto",
         "//kythe/proto:go_go_proto",
         "//kythe/proto:java_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
     ],
 )

--- a/kythe/go/services/web/BUILD
+++ b/kythe/go/services/web/BUILD
@@ -7,7 +7,7 @@ go_library(
     srcs = ["web.go"],
     deps = [
         "//kythe/go/util/httpencoding",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/storage/stream/BUILD
+++ b/kythe/go/storage/stream/BUILD
@@ -10,7 +10,7 @@ go_library(
         "//kythe/go/util/schema/facts",
         "//kythe/proto:common_go_proto",
         "//kythe/proto:storage_go_proto",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
     ],
 )

--- a/kythe/go/util/ptypes/BUILD
+++ b/kythe/go/util/ptypes/BUILD
@@ -7,7 +7,7 @@ go_library(
     srcs = ["ptypes.go"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@io_bazel_rules_go//proto/wkt:any_go_proto",
     ],
 )

--- a/third_party/beam/BUILD
+++ b/third_party/beam/BUILD
@@ -27,7 +27,7 @@ go_library(
         "@com_github_apache_beam//sdks/go/pkg/beam/log:go_default_library",
         "@com_github_apache_beam//sdks/go/pkg/beam/runners/direct:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )


### PR DESCRIPTION
Upgrading our Bazel Go rules in #2963 causes link warnings like below:

```
GoLink: warning: package "github.com/golang/protobuf/ptypes/any" is provided by more than one rule:
    @com_github_golang_protobuf//ptypes/any:go_default_library
    @io_bazel_rules_go//proto/wkt:any_go_proto
Set "importmap" to different paths in each library.
This will be an error in the future.
```

This happens due to a mismatch between our direct dependencies on
`@io_bazel_rules_go//proto/wkt:all` targets and our indirect
dependencies on the proto types in `@com_github_golang_protobuf` through
the `ptypes` and `jsonpb` packages.  There are mirrored `_gen` targets
that fix this by relying on the `wkt` targets in `@io_bazel_rules_go`.

See https://github.com/bazelbuild/rules_go/blob/af616aa6b82e3d3a295d0ba2776b41af7f376c8f/proto/core.rst#option-1-use-go-proto-library-exclusively