### PR TITLE
Analysis protocol: Clarify request lifetime.

### DIFF
--- a/kythe/docs/rfc/2966.md
+++ b/kythe/docs/rfc/2966.md
@@ -93,11 +93,11 @@ analyzer. Some important goals of this proposal are:
     server MUST support batch JSON-RPC requests from the analyzer.
 
 -   Under certain circumstances, the analyzer process **must exit**. In a case
-    where the analyzer process must exit, it must terminate within a grace
-    period. If it does not, the process may be forcibly terminated at any time
-    by the operating environment. The exit code of an analyzer process is
-    ignored. The grace period is defined by the environment, but must be at
-    least 10 seconds.
+    where the analyzer process must exit, it MUST terminate within a grace
+    period. If it does not, the operating environment SHOULD forcibly terminate
+    the process (and may do so at any time after the grace period ends). The
+    exit code of an analyzer process is ignored. The grace period is defined by
+    the implementation, but must be at least 10 seconds.
 
 -   If and after the analyzer closes the output stream, the analyzer process
     must exit.
@@ -113,6 +113,10 @@ analyzer. Some important goals of this proposal are:
     If the analyzer receives a corrupt frame from the driver, it must exit. If
     the driver receives a corrupt frame from the analyzer, it must close the
     input stream (in which case the analyzer therefore must exit).
+
+-   When an analyzer process terminates, the driver MUST consider any pending
+    analysis requests to have failed, and thereafter the environment MAY retry
+    analysis of the corresponding compilation records.
 
 ### Messages
 
@@ -234,6 +238,10 @@ A driver defines the following JSON-RPC methods:
     Request a fresh compilation record from the environment, blocking until one
     is available. The environment assigns a unique integer analysis ID to each
     request, distinct from any other ID currently assigned to that analyzer.
+    Once an analysis ID has been assigned, it is designated as **pending** until
+    the analyzer sends a `done` notification (see below) for that ID. A driver
+    SHOULD NOT issue the same compilation record again while there is a pending
+    analysis ID for that record.
 
     Example:
 
@@ -277,9 +285,9 @@ A driver defines the following JSON-RPC methods:
 
     A notification from the analyzer to the environment, signifying that the
     analyzer has completed work on the specified analysis ID. The environment
-    does not reply. After receiving this notification, any further requests for
-    the analysis ID will be discarded (and return an error, if appropriate),
-    unless and until the environment issues a new analysis reusing the ID.
+    does not reply. After receiving this notification, the driver MUST discard
+    any further requests for the analysis ID (and return an error, if
+    appropriate) unless and until it issues a new analysis reusing that ID.
 
     Example:
 


### PR DESCRIPTION
Specify the handling of analysis requests that were not yet reported as done
when the analyzer process terminates. Define the term "pending". Clarify the
obligations of the driver in cleaning up after a failed analyzer.