### PR TITLE
Support new location for project-specific Bazel options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+import '%workspace%/tools/bazel.rc'
+build --unconditional_warning="~/.bazelrc may not be being read, consider passing it through the --bazelrc flag."

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,3 +1,5 @@
+# TODO(#2897): move to %workspace%/.bazelrc
+
 build --workspace_status_command tools/buildstamp/get_workspace_status
 build --auto_cpu_environment_group=//buildenv:cpu
 


### PR DESCRIPTION
This supports a decent transition for #2897.  Once we drop support for 0.16, we'll be able to remove the warning and move our settings directly to the new `%workspace%/.bazelrc` location.