### PR TITLE
Use our own custom shasum tool

### DIFF
--- a/kythe/docs/schema/asciidoc_with_verifier.bzl
+++ b/kythe/docs/schema/asciidoc_with_verifier.bzl
@@ -21,6 +21,7 @@ def asciidoc_with_verifier(name, src):
             "java-schema-unit-template.CompilationUnit",
             "//kythe/cxx/indexer/cxx:indexer",
             "//kythe/go/indexer/cmd/go_example:go_example",
+            "//kythe/go/platform/tools/shasum_tool",
             "//kythe/java/com/google/devtools/kythe/analyzers/java:indexer",
             "//kythe/cxx/tools:kindex_tool",
             "//kythe/cxx/verifier",
@@ -38,6 +39,7 @@ def build_example_sh():
         "JAVA_INDEXER_BIN": "//kythe/java/com/google/devtools/kythe/analyzers/java:indexer",
         "KINDEX_TOOL_BIN": "//kythe/cxx/tools:kindex_tool",
         "VERIFIER_BIN": "//kythe/cxx/verifier",
+        "SHASUM_TOOL": "//kythe/go/platform/tools/shasum_tool:shasum_tool",
     }
     fixes = [
         "-e '/^export %s=/{i\\\n_p=($(locations %s))\ns#$$#\"$$ROOT/$${_p[0]}\"#\n}'" % (key, target)

--- a/kythe/docs/schema/example-base.sh
+++ b/kythe/docs/schema/example-base.sh
@@ -34,6 +34,7 @@ export GO_INDEXER_BIN=
 export JAVA_INDEXER_BIN=
 export KINDEX_TOOL_BIN=
 export VERIFIER_BIN=
+export SHASUM_TOOL=
 
 export LANGUAGE="$3"
 export LABEL="$4"

--- a/kythe/docs/schema/example-cxx.sh
+++ b/kythe/docs/schema/example-cxx.sh
@@ -25,6 +25,7 @@ set -o pipefail
 #   LABEL
 #   CXX_INDEXER_BIN
 #   VERIFIER_BIN
+#   SHASUM_TOOL
 #   SHOWGRAPH
 #   VERIFIER_ARGS
 
@@ -88,7 +89,7 @@ done
 "$VERIFIER_BIN" "${VERIFIER_ARGS}" --ignore_dups "${SRCS}"/* < "${TEST_ENTRIES}"
 
 trap 'error FORMAT' ERR
-EXAMPLE_ID=$(shasum -a 256 "$RAW_EXAMPLE" | cut -c 1-64)
+EXAMPLE_ID=$($SHASUM_TOOL "$RAW_EXAMPLE" | cut -c 1-64)
 
 if [[ -n "${DIV_STYLE}" ]]; then
   echo "<div style=\"${DIV_STYLE}\">"

--- a/kythe/docs/schema/example-dot.sh
+++ b/kythe/docs/schema/example-dot.sh
@@ -25,10 +25,11 @@ set -o pipefail
 #   LABEL
 #   CXX_INDEXER_BIN
 #   VERIFIER_BIN
+#   SHASUM_TOOL
 
 RAW_EXAMPLE="$TMP/raw.dot"
 cat > "${RAW_EXAMPLE}"
-EXAMPLE_ID="$(shasum -a 256 "${RAW_EXAMPLE}" | cut -c 1-64)"
+EXAMPLE_ID="$($SHASUM_TOOL "${RAW_EXAMPLE}" | cut -c 1-64)"
 dot -Tsvg -o "${EXAMPLE_ID}.svg" "${RAW_EXAMPLE}"
 echo "<div>"
 cat "${EXAMPLE_ID}.svg"

--- a/kythe/docs/schema/example-go.sh
+++ b/kythe/docs/schema/example-go.sh
@@ -26,6 +26,7 @@ set -o pipefail
 #   LABEL
 #   GO_INDEXER_BIN
 #   VERIFIER_BIN
+#   SHASUM_TOOL
 #   SHOWGRAPH
 
 readonly PKGDIR="$TMP/pkg"
@@ -38,7 +39,7 @@ readonly ENTRIES="$TMP/example.entries"
 "$VERIFIER_BIN" --use_file_nodes < "$ENTRIES"
 
 trap 'error FORMAT' ERR
-readonly EXAMPLE_ID=$(shasum -a 256 "$SRCFILE" | cut -c 1-64)
+readonly EXAMPLE_ID=$($SHASUM_TOOL "$SRCFILE" | cut -c 1-64)
 
 if [[ -n "$DIV_STYLE" ]] ; then
   echo "<div style=\"${DIV_STYLE}\">"

--- a/kythe/docs/schema/example-java.sh
+++ b/kythe/docs/schema/example-java.sh
@@ -24,8 +24,9 @@ set -o pipefail
 #   LANGUAGE
 #   LABEL
 #   JAVA_INDEXER_BIN
-#   VERIFIER_BIN
 #   KINDEX_TOOL_BIN
+#   VERIFIER_BIN
+#   SHASUM_TOOL
 #   SHOWGRAPH
 #
 # TODO(zarko): Provide alternate templates to avoid unnecessary boilerplate
@@ -34,7 +35,7 @@ set -o pipefail
 # Save the Java source example
 TEST_FILE="$TMP/E.java"
 tee "$TEST_FILE.orig" > "$TEST_FILE"
-FILE_SHA=$(shasum -a 256 "${TEST_FILE}.orig" | cut -c 1-64)
+FILE_SHA=$($SHASUM_TOOL "${TEST_FILE}.orig" | cut -c 1-64)
 
 # Convert to ascii proto format; escape backslashes, quotes, and newlines.
 python <<EOF > "${TEST_FILE}.FileData"

--- a/kythe/docs/schema/example-objc.sh
+++ b/kythe/docs/schema/example-objc.sh
@@ -25,6 +25,7 @@ set -o pipefail
 #   LABEL
 #   CXX_INDEXER_BIN
 #   VERIFIER_BIN
+#   SHASUM_TOOL
 #   SHOWGRAPH
 
 SRCS="$TMP/example"
@@ -87,7 +88,7 @@ done
 "$VERIFIER_BIN" --ignore_dups "${SRCS}"/* < "${TEST_ENTRIES}"
 
 trap 'error FORMAT' ERR
-EXAMPLE_ID=$(shasum -a 256 "$RAW_EXAMPLE" | cut -c 1-64)
+EXAMPLE_ID=$($SHASUM_TOOL "$RAW_EXAMPLE" | cut -c 1-64)
 
 if [[ -n "${DIV_STYLE}" ]]; then
   echo "<div style=\"${DIV_STYLE}\">"

--- a/tools/build_rules/external_tools/external_tools_configure.bzl
+++ b/tools/build_rules/external_tools/external_tools_configure.bzl
@@ -46,7 +46,6 @@ def _external_toolchain_autoconf_impl(repository_ctx):
         "tee",
         "rm",
         "cut",
-        "shasum",
         "sed",
         "readlink",
     ]


### PR DESCRIPTION
shasum is a perl script, which means it is tricky to put in the bazel
sandbox. On Linux, you execute shasum, but on macOS apparently the perl
wrapper finds the right version of the shasum and executes that. Since
we already have our own shasum binary, we should just use that and make
this problem go away.

Part of #2967 