### PR TITLE
Go indexer: Fix more anonymous struct field declarations.

### DIFF
--- a/kythe/go/indexer/emit.go
+++ b/kythe/go/indexer/emit.go
@@ -329,7 +329,9 @@ func (e *emitter) visitTypeSpec(spec *ast.TypeSpec, stack stackFunc) {
 		if st, ok := spec.Type.(*ast.StructType); ok {
 			mapFields(st.Fields, func(i int, id *ast.Ident) {
 				target := e.writeVarBinding(id, nodes.Field, nil)
-				e.writeDoc(st.Fields.List[i].Doc, target)
+				f := st.Fields.List[i]
+				e.writeDoc(f.Doc, target)
+				e.emitAnonFields(f.Type)
 			})
 
 			// Handle anonymous fields. Such fields behave as if they were

--- a/kythe/go/indexer/testdata/basic/anonymous.go
+++ b/kythe/go/indexer/testdata/basic/anonymous.go
@@ -63,3 +63,14 @@ var g = func(elt struct {
 	//- @elt ref Elt
 	return len(elt.P)
 }
+
+//- @em defines/binding Em
+//- Em.node/kind record
+type em struct {
+	v struct {
+		//- @X defines/binding EmX
+		//- EmX.node/kind variable
+		//- EmX.subkind field
+		X string
+	}
+}


### PR DESCRIPTION
Similar to #2828, this commit ensures that the fields of struct type
declarations also get their subfields decorated, when those subfields are of
anonymous struct type.

Fixes #2984.