### PR TITLE
Update gradlecmd to support different javacWrapper

### DIFF
--- a/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
+++ b/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
@@ -78,7 +78,7 @@ func (g *gradleCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...i
 		return g.Fail("error backing up %s: %v", g.buildFile, err)
 	}
 	defer tf.Release()
-	if err := PreProcessGradleBuild(g.buildFile); err != nil {
+	if err := PreProcessGradleBuild(g.buildFile, g.javacWrapper); err != nil {
 		return g.Fail("error modifying %s: %v", g.buildFile, err)
 	}
 	if err := exec.Command("gradle", "build").Run(); err != nil {

--- a/kythe/go/extractors/config/runextractor/gradlecmd/testdata/modified-gradle.build
+++ b/kythe/go/extractors/config/runextractor/gradlecmd/testdata/modified-gradle.build
@@ -13,7 +13,7 @@ allprojects {
   gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
       options.fork = true
-      options.forkOptions.executable = '/opt/kythe/extractors/javac-wrapper.sh'
+      options.forkOptions.executable = '/tmp/javac-wrapper.sh'
     }
   }
 }

--- a/kythe/go/extractors/config/runextractor/gradlecmd/testdata/other-gradle.build
+++ b/kythe/go/extractors/config/runextractor/gradlecmd/testdata/other-gradle.build
@@ -14,7 +14,7 @@ allprojects {
   gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
       options.fork = true
-      options.forkOptions.executable = '/some-other/javac-wrapper.sh'
+      options.forkOptions.executable = '/different/javac-wrapper.sh'
     }
   }
 }


### PR DESCRIPTION
Previously hardcoded this to /opt/kythe/extractors/javac-wrapper.sh,
which works fine in the current docker image, but probably should be
configurable.