### PR TITLE
Fix another singleton variable in the marked-source example.

### DIFF
--- a/kythe/docs/schema/marked-source.txt
+++ b/kythe/docs/schema/marked-source.txt
@@ -254,6 +254,6 @@ $$C++$$ variable:
 //- VXSpaceBox.pre_text " "
 //- VXRoot child.2 VXIdentifier
 //- VXIdentifier.kind "IDENTIFIER"
-//- VXIdenfifier.pre_text x
+//- VXIdentifier.pre_text x
 int x;
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The singleton check did its job here -- we had a typo in the evar.