### PR TITLE
Default extracted verifier tests to not check for singletons.

### DIFF
--- a/kythe/docs/schema/example-java.sh
+++ b/kythe/docs/schema/example-java.sh
@@ -26,6 +26,7 @@ set -o pipefail
 #   JAVA_INDEXER_BIN
 #   KINDEX_TOOL_BIN
 #   VERIFIER_BIN
+#   VERIFIER_ARGS
 #   SHASUM_TOOL
 #   SHOWGRAPH
 #
@@ -55,7 +56,7 @@ if ! "$JAVA_INDEXER_BIN" "${TEST_FILE}.kindex" >"${TEST_FILE}.entries"; then
 fi
 
 # Verify the index.
-if ! "$VERIFIER_BIN" --ignore_dups "${TEST_FILE}.orig" <"${TEST_FILE}.entries"; then
+if ! "$VERIFIER_BIN" "${VERIFIER_ARGS}" --ignore_dups "${TEST_FILE}.orig" <"${TEST_FILE}.entries"; then
   error VERIFY
 fi
 

--- a/kythe/docs/schema/example-objc.sh
+++ b/kythe/docs/schema/example-objc.sh
@@ -25,6 +25,7 @@ set -o pipefail
 #   LABEL
 #   CXX_INDEXER_BIN
 #   VERIFIER_BIN
+#   VERIFIER_ARGS
 #   SHASUM_TOOL
 #   SHOWGRAPH
 
@@ -85,7 +86,7 @@ do
   "$CXX_INDEXER_BIN" --ignore_unimplemented=false -i "${TEST_M}" -- $CXX_ARGS \
       >> "${TEST_ENTRIES}"
 done
-"$VERIFIER_BIN" --ignore_dups "${SRCS}"/* < "${TEST_ENTRIES}"
+"$VERIFIER_BIN" "${VERIFIER_ARGS}" --ignore_dups "${SRCS}"/* < "${TEST_ENTRIES}"
 
 trap 'error FORMAT' ERR
 EXAMPLE_ID=$($SHASUM_TOOL "$RAW_EXAMPLE" | cut -c 1-64)

--- a/kythe/docs/schema/kythe-filter.conf
+++ b/kythe/docs/schema/kythe-filter.conf
@@ -33,7 +33,7 @@
 # ------------------------------------------------------------------------------
 
 [kythe-filter-style]
-kythe-style=template="passblock",posattrs=("style","language","label","graph","divstyle","verifierargs"),filter="{example_script} {backend} {style} {language} {label} {graph=1} {divstyle=''} {verifierargs=''}",subs=()
+kythe-style=template="passblock",posattrs=("style","language","label","graph","divstyle","verifierargs"),filter="{example_script} {backend} {style} {language} {label} {graph=1} {divstyle=''} {verifierargs='--nocheck_for_singletons'}",subs=()
 
 [blockdef-listing]
 template::[kythe-filter-style]


### PR DESCRIPTION
The examples embedded in the schema and other related docs have a lot of
variables that are used only once (i.e., singletons), which trip on the
verifier now that the default is to flag singletons.

For example purposes it's fine to have singletons -- the check is there to
avert typographical errors in unit tests. Errors could also happen in the
examples, but the unit tests should be catching any real bugs that might be
disguised in that case.