### PR TITLE
Make the asciidoc rule emit outputs to a zip file.

### DIFF
--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -30,7 +30,12 @@ bazel --bazelrc=/dev/null build //kythe/docs/... //kythe/docs/schema \
     //kythe/docs/schema:writing-an-indexer \
     //kythe/docs/schema:indexing-protobuf \
     //kythe/docs/schema:marked-source
+# Copy the zipped asciidoc outputs into the staging directory, unpack the
+# archives, then remove them. We do this to ensure the output retains the
+# directory structure of the source tree.
 rsync -Lr --chmod=a+w --delete "bazel-bin/kythe/docs/" "$DIR"/_docs
+find "$DIR"/_docs -type f -name '*.zip' -execdir unzip -q {} ';' -delete
+
 DOCS=($(bazel query 'kind("source file", deps(//kythe/docs/..., 1))' | \
   grep -E '\.(txt|adoc|ad)$' | \
   parallel --gnu -L1 'x() { file="$(tr : / <<<"$1")"; echo ${file#//kythe/docs/}; }; x'))

--- a/tools/build_rules/external_tools/external_tools_configure.bzl
+++ b/tools/build_rules/external_tools/external_tools_configure.bzl
@@ -34,20 +34,21 @@ def _external_toolchain_autoconf_impl(repository_ctx):
     # These are the tools that the doc/schema generation need beyond the
     # explicit call to asciidoc.
     tools = [
-        "dot",
-        "python",
-        "grep",
-        "cat",
-        "source-highlight",
-        "mktemp",
-        "mkdir",
-        "touch",
         "awk",
-        "tee",
-        "rm",
+        "cat",
         "cut",
-        "sed",
+        "dot",
+        "grep",
+        "mkdir",
+        "mktemp",
+        "python",
         "readlink",
+        "rm",
+        "sed",
+        "source-highlight",
+        "tee",
+        "touch",
+        "zip",
     ]
     for tool in tools:
         symlink_command(repository_ctx, tool)


### PR DESCRIPTION
Because asciidoc may generate an unknown number of output files (as the result of running filters), 
fix the rule to capture these in a ZIP file instead.  Also add some documentation so that future readers 
can see what's going on. This addresses an issue where recent versions of Bazel, which have become
more aggressive about cleaning up the sandbox after an action executes, would lose the support files
from the asciidoc filters.

Also update the website documentation builder to account for the above.