### PR TITLE
Site sync: Explicitly build the schema-overview doc.

### DIFF
--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -24,7 +24,9 @@ export SHELL=/bin/bash
 DIR="$(readlink -e "$(dirname "$0")")"
 cd "$DIR/../../.."
 
-bazel --bazelrc=/dev/null build //kythe/docs/... //kythe/docs/schema \
+bazel --bazelrc=/dev/null build //kythe/docs/... \
+    //kythe/docs:schema-overview \
+    //kythe/docs/schema \
     //kythe/docs/schema:callgraph \
     //kythe/docs/schema:verifierstyle \
     //kythe/docs/schema:writing-an-indexer \


### PR DESCRIPTION
This rule is marked manual to work around missing files in buildbot.  So to
make it go out on the website, we need to build it explicitly rather than via
the glob.