### PR TITLE
Go: Mark result parameters as part of the TYPE in MarkedSource.

### DIFF
--- a/kythe/go/indexer/indexer.go
+++ b/kythe/go/indexer/indexer.go
@@ -547,7 +547,7 @@ func (pi *PackageInfo) MarkedSource(obj types.Object) *cpb.MarkedSource {
 			})
 		}
 		if res := sig.Results(); res != nil && res.Len() > 0 {
-			rms := &cpb.MarkedSource{PreText: " "}
+			rms := &cpb.MarkedSource{Kind: cpb.MarkedSource_TYPE, PreText: " "}
 			if res.Len() > 1 {
 				// If there is more than one result type, parenthesize.
 				rms.PreText = " ("

--- a/kythe/go/indexer/testdata/code/methdecl.go
+++ b/kythe/go/indexer/testdata/code/methdecl.go
@@ -29,6 +29,7 @@ type w struct{}
 //- LTParams.post_child_text ", "
 //-
 //- LTResult.pre_text " "
+//- LTResult.kind "TYPE"
 //- LTResult child.0 LTReturn
 //- LTReturn.pre_text "bool"
 //-


### PR DESCRIPTION
This is to address a user complaint that hovercards do not include the result
types in the rendering.