### PR TITLE
Always build gradle clean.

### DIFF
--- a/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
+++ b/kythe/go/extractors/config/runextractor/gradlecmd/gradlecmd.go
@@ -81,7 +81,7 @@ func (g *gradleCommand) Execute(ctx context.Context, fs *flag.FlagSet, args ...i
 	if err := PreProcessGradleBuild(g.buildFile, g.javacWrapper); err != nil {
 		return g.Fail("error modifying %s: %v", g.buildFile, err)
 	}
-	if err := exec.Command("gradle", "build").Run(); err != nil {
+	if err := exec.Command("gradle", "clean", "build").Run(); err != nil {
 		return g.Fail("error executing gradle build: %v", err)
 	}
 	if err := tf.Restore(); err != nil {


### PR DESCRIPTION
Note this doesn't affect most normal operation since we would tend to
run this inside of a docker container that sets up a clean environment
every time.  However, for both local testing and possibly future usage,
we might not want to assume that - so do a 'gradle clean build' instead
of 'gradle build'.  This means if we're re-using the environment for
whatever reason (maybe to make it cheaper and less overhead? who knows),
we won't sometimes mysteriously get no extraction results.

(sub-1-line pull request with a lengthy explanation, but probably worth it
for posterity)