### PR TITLE
Add a 'nobuildbot' label for skipping buildbot.

### DIFF
--- a/kythe/release/appengine/buildbot/master/master.cfg.template
+++ b/kythe/release/appengine/buildbot/master/master.cfg.template
@@ -53,8 +53,14 @@ autoBuildUsers = [
     'zrlk',
 ]
 def pullRequestFilter(req):
+  # Blacklist anything that explicitly says 'nobuildbot'
+  for label in req['labels']:
+    if label['name'] == 'nobuildbot':
+      return False
+  # Default buildbot all maintainer commits
   if req['user']['login'] in autoBuildUsers:
     return True
+  # Also allow explicitly labeled commits by non-maintainers
   for label in req['labels']:
     if label['name'] == 'buildbot':
       return True


### PR DESCRIPTION
Presumably if you know for sure build isn't relevant (say the commit
doesn't affect buildable files), or if buildbot itself is hosed, give
ourselves an easy out.

(I didn't know if we already had some way to do this, if so we can
just kill this commit)