### PR TITLE
Remove concurrency from Beam disksort runner

### DIFF
--- a/third_party/beam/BUILD
+++ b/third_party/beam/BUILD
@@ -28,7 +28,6 @@ go_library(
         "@com_github_apache_beam//sdks/go/pkg/beam/runners/direct:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/third_party/beam/sdks/go/pkg/beam/runners/disksort/gbk_test.go
+++ b/third_party/beam/sdks/go/pkg/beam/runners/disksort/gbk_test.go
@@ -25,9 +25,6 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/x/debug"
 )
 
-// Disable parallelism to work with order-dependent passert checks.
-func init() { *gbkConcurrency = 1 }
-
 func TestGBK(t *testing.T) {
 	p, s, nums := ptest.CreateList([]int{1, 2, 3, 4, 2, 3, 3})
 


### PR DESCRIPTION
Since https://github.com/apache/beam/pull/5882, the GBK concurrency causes races in the core Beam executor and cannot be supported.