### PR TITLE
Remove irrelevant location parameter from BuildNodeIdForTemplate{Name…

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.cc
@@ -1527,8 +1527,7 @@ IndexerASTVisitor::BuildNodeIdForImplicitClassTemplateInstantiation(
                         : Optional<ArrayRef<TemplateArgumentLoc>>(),
           CTSD->getTemplateArgs().asArray(), NIDS, NIDPS)) {
     if (auto SpecializedNode = BuildNodeIdForTemplateName(
-            clang::TemplateName(CTSD->getSpecializedTemplate()),
-            CTSD->getPointOfInstantiation())) {
+            clang::TemplateName(CTSD->getSpecializedTemplate()))) {
       if (PrimaryOrPartial.is<clang::ClassTemplateDecl*>() &&
           !isa<const clang::ClassTemplatePartialSpecializationDecl>(CTSD)) {
         // Point to a tapp of the primary template.
@@ -1631,8 +1630,7 @@ IndexerASTVisitor::BuildNodeIdForImplicitFunctionTemplateInstantiation(
       // If there's more than one possible template name (e.g., this is
       // dependent), choose one arbitrarily.
       for (const auto& TN : TNs) {
-        if (auto SpecializedNode =
-                BuildNodeIdForTemplateName(TN.first, TN.second)) {
+        if (auto SpecializedNode = BuildNodeIdForTemplateName(TN.first)) {
           return Observer.recordTappNode(SpecializedNode.value(), NIDPS,
                                          NumArgsAsWritten);
         }
@@ -1894,8 +1892,7 @@ bool IndexerASTVisitor::VisitVarDecl(const clang::VarDecl* Decl) {
                           : Optional<ArrayRef<TemplateArgumentLoc>>(),
             VTSD->getTemplateArgs().asArray(), NIDS, NIDPS)) {
       if (auto SpecializedNode = BuildNodeIdForTemplateName(
-              clang::TemplateName(VTSD->getSpecializedTemplate()),
-              VTSD->getPointOfInstantiation())) {
+              clang::TemplateName(VTSD->getSpecializedTemplate()))) {
         if (PrimaryOrPartial.is<clang::VarTemplateDecl*>() &&
             !isa<const clang::VarTemplatePartialSpecializationDecl>(Decl)) {
           // This is both an instance and a specialization of the primary
@@ -2499,8 +2496,7 @@ bool IndexerASTVisitor::VisitRecordDecl(const clang::RecordDecl* Decl) {
                           : Optional<ArrayRef<TemplateArgumentLoc>>(),
             CTSD->getTemplateArgs().asArray(), NIDS, NIDPS)) {
       if (auto SpecializedNode = BuildNodeIdForTemplateName(
-              clang::TemplateName(CTSD->getSpecializedTemplate()),
-              CTSD->getPointOfInstantiation())) {
+              clang::TemplateName(CTSD->getSpecializedTemplate()))) {
         if (PrimaryOrPartial.is<clang::ClassTemplateDecl*>() &&
             !isa<const clang::ClassTemplatePartialSpecializationDecl>(Decl)) {
           // This is both an instance and a specialization of the primary
@@ -2716,8 +2712,7 @@ bool IndexerASTVisitor::VisitFunctionDecl(clang::FunctionDecl* Decl) {
                             ? GraphObserver::Confidence::Speculative
                             : GraphObserver::Confidence::NonSpeculative;
       for (const auto& TN : TNs) {
-        if (auto SpecializedNode =
-                BuildNodeIdForTemplateName(TN.first, TN.second)) {
+        if (auto SpecializedNode = BuildNodeIdForTemplateName(TN.first)) {
           // Because partial specialization of function templates is forbidden,
           // instantiates edges will always choose the same type (a tapp with
           // the primary template as its first argument) as specializes edges.
@@ -3482,8 +3477,7 @@ IndexerASTVisitor::ApplyBuiltinTypeConstructor(
 }
 
 absl::optional<GraphObserver::NodeId>
-IndexerASTVisitor::BuildNodeIdForTemplateName(const clang::TemplateName& Name,
-                                              const clang::SourceLocation L) {
+IndexerASTVisitor::BuildNodeIdForTemplateName(const clang::TemplateName& Name) {
   // TODO(zarko): Do we need to canonicalize `Name`?
   // Maybe with Context.getCanonicalTemplateName()?
   switch (Name.getKind()) {
@@ -3500,9 +3494,7 @@ IndexerASTVisitor::BuildNodeIdForTemplateName(const clang::TemplateName& Name,
           // BuildNodeIdForDecl() all the time makes sense. We aren't even
           // emitting ranges.
           if (const auto* TDType = TD->getTypeForDecl()) {
-            QualType QT(TDType, 0);
-            TypeSourceInfo* TSI = Context.getTrivialTypeSourceInfo(QT, L);
-            return BuildNodeIdForType(TSI->getTypeLoc(), EmitRanges::No);
+            return BuildNodeIdForType(QualType(TDType, 0));
           } else if (const auto* TAlias = dyn_cast<TypeAliasDecl>(TD)) {
             // The names for type alias types are the same for type alias nodes.
             return BuildNodeIdForTypedefNameDecl(TAlias);
@@ -3684,9 +3676,8 @@ GraphObserver::NodeId IndexerASTVisitor::BuildNodeIdForSpecialTemplateArgument(
 }
 
 absl::optional<GraphObserver::NodeId>
-IndexerASTVisitor::BuildNodeIdForTemplateExpansion(clang::TemplateName Name,
-                                                   clang::SourceLocation L) {
-  return BuildNodeIdForTemplateName(Name, L);
+IndexerASTVisitor::BuildNodeIdForTemplateExpansion(clang::TemplateName Name) {
+  return BuildNodeIdForTemplateName(Name);
 }
 
 absl::optional<GraphObserver::NodeId> IndexerASTVisitor::BuildNodeIdForExpr(
@@ -3763,10 +3754,10 @@ IndexerASTVisitor::BuildNodeIdForTemplateArgument(
       return BuildNodeIdForSpecialTemplateArgument(
           Arg.getAsIntegral().toString(10) + "i");
     case TemplateArgument::Template:
-      return BuildNodeIdForTemplateName(Arg.getAsTemplate(), L);
+      return BuildNodeIdForTemplateName(Arg.getAsTemplate());
     case TemplateArgument::TemplateExpansion:
       return BuildNodeIdForTemplateExpansion(
-          Arg.getAsTemplateOrTemplatePattern(), L);
+          Arg.getAsTemplateOrTemplatePattern());
     case TemplateArgument::Expression:
       CHECK(Arg.getAsExpr() != nullptr);
       return BuildNodeIdForExpr(Arg.getAsExpr(), EmitRanges::Yes);
@@ -3811,11 +3802,10 @@ IndexerASTVisitor::BuildNodeIdForTemplateArgument(
       return BuildNodeIdForSpecialTemplateArgument(
           Arg.getAsIntegral().toString(10) + "i");
     case TemplateArgument::Template:
-      return BuildNodeIdForTemplateName(Arg.getAsTemplate(),
-                                        ArgLoc.getTemplateNameLoc());
+      return BuildNodeIdForTemplateName(Arg.getAsTemplate());
     case TemplateArgument::TemplateExpansion:
       return BuildNodeIdForTemplateExpansion(
-          Arg.getAsTemplateOrTemplatePattern(), ArgLoc.getTemplateNameLoc());
+          Arg.getAsTemplateOrTemplatePattern());
     case TemplateArgument::Expression:
       CHECK(ArgLoc.getSourceExpression() != nullptr);
       return BuildNodeIdForExpr(ArgLoc.getSourceExpression(), EmitRanges);
@@ -4359,8 +4349,8 @@ absl::optional<GraphObserver::NodeId> IndexerASTVisitor::BuildNodeIdForType(
       // appear as different types.
       const auto& T = TypeLoc.castAs<TemplateSpecializationTypeLoc>();
       const SourceLocation& TNameLoc = T.getTemplateNameLoc();
-      auto TemplateName = BuildNodeIdForTemplateName(
-          T.getTypePtr()->getTemplateName(), TNameLoc);
+      auto TemplateName =
+          BuildNodeIdForTemplateName(T.getTypePtr()->getTemplateName());
       if (!TemplateName) {
         return TemplateName;
       }

--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -219,9 +219,8 @@ class IndexerASTVisitor : public clang::RecursiveASTVisitor<IndexerASTVisitor> {
 
   /// \brief Builds a stable node ID for a template expansion template argument.
   /// \param Name The template pattern being expanded.
-  /// \param L The location of the expansion.
   absl::optional<GraphObserver::NodeId> BuildNodeIdForTemplateExpansion(
-      clang::TemplateName Name, clang::SourceLocation L);
+      clang::TemplateName Name);
 
   /// \brief Builds a stable node ID for `Type`.
   /// \param TypeLoc The type that is being identified. If its location is valid
@@ -281,7 +280,7 @@ class IndexerASTVisitor : public clang::RecursiveASTVisitor<IndexerASTVisitor> {
 
   /// \brief Builds a stable node ID for the given `TemplateName`.
   absl::optional<GraphObserver::NodeId> BuildNodeIdForTemplateName(
-      const clang::TemplateName& Name, clang::SourceLocation L);
+      const clang::TemplateName& Name);
 
   /// \brief Builds a stable node ID for the given `TemplateArgument`.
   absl::optional<GraphObserver::NodeId> BuildNodeIdForTemplateArgument(


### PR DESCRIPTION
…,Expansion}

The location parameter is ultimately passed to `BuildNodeIdForType(.., EmitRanges::No)` which then dutifully disregards the location.