### PR TITLE
Split type MarkedSource nodes containing decl names

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2409,6 +2409,14 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "ms_array",
+    srcs = ["marked_source/ms_array.cc"],
+    convert_marked_source = True,
+    std = "c++14",
+    tags = ["marked_source"],
+)
+
+cc_indexer_test(
     name = "ms_class",
     srcs = ["marked_source/ms_class.cc"],
     convert_marked_source = True,

--- a/kythe/cxx/indexer/cxx/testdata/marked_source/ms_array.cc
+++ b/kythe/cxx/indexer/cxx/testdata/marked_source/ms_array.cc
@@ -1,0 +1,21 @@
+// Array-typed variables have proper MarkedSource.
+namespace n {
+//- @x defines/binding VarX
+//- VarX code MsX
+//- MsX child.0 MsTypePart0
+//- MsX child.1 MsBoxCxtId
+//- MsX child.2 MsTypePart1
+//- MsTypePart0.kind "TYPE"
+//- MsTypePart0.pre_text "char "
+//- MsBoxCxtId child.0 CxtNs
+//- CxtNs.kind "CONTEXT"
+//- CxtNs child.0 Ns
+//- Ns.kind "IDENTIFIER"
+//- Ns.pre_text "n"
+//- MsBoxCxtId child.1 Id
+//- Id.pre_text "x"
+//- Id.kind "IDENTIFIER"
+//- MsTypePart1.kind "TYPE"
+//- MsTypePart1.pre_text "[]"
+char x[] = {1, 2};
+}


### PR DESCRIPTION
We had been doing this for functions, but we should
also do it for variables and fields.

Addresses #3039.