### PR TITLE
Add //kythe/docs/schema to Buildbot release tests

### DIFF
--- a/kythe/docs/schema/BUILD
+++ b/kythe/docs/schema/BUILD
@@ -7,6 +7,7 @@ build_example_sh()
 asciidoc_with_verifier(
     name = "schema",
     src = "schema.txt",
+    tags = ["manual"],
 )
 
 asciidoc_with_verifier(

--- a/kythe/docs/schema/asciidoc_with_verifier.bzl
+++ b/kythe/docs/schema/asciidoc_with_verifier.bzl
@@ -1,6 +1,6 @@
 load("//kythe/docs:asciidoc.bzl", "asciidoc")
 
-def asciidoc_with_verifier(name, src):
+def asciidoc_with_verifier(name, src, tags = None):
     """Invoke the asciidoc tool on the specified source file, filtering examples to
     be passed to the verifier. If the verifier does not succeed, the build will fail.
     """
@@ -26,7 +26,7 @@ def asciidoc_with_verifier(name, src):
             "//kythe/cxx/tools:kindex_tool",
             "//kythe/cxx/verifier",
         ],
-        tags = ["manual"],
+        tags = tags,
     )
 
 def build_example_sh():

--- a/kythe/release/appengine/buildbot/master/master.cfg.template
+++ b/kythe/release/appengine/buildbot/master/master.cfg.template
@@ -86,7 +86,6 @@ allBuilders = [
     "bazel-0.16.0",
     "bazel-0.17.1",
     "bazel-release",
-    "bazel-opt",
     "go-1.11-gopath",
     "go-1.11-module"
 ]
@@ -117,7 +116,7 @@ bazelKytheSteps.addStep(steps.ShellCommand(
 bazelKytheSteps.addStep(steps.ShellCommand(
     command=["bazel", "test", "-k",
              util.Property('bazel_flags', default=[]), 
-             util.Property('bazel_target', default='//...')],
+             util.Property('bazel_targets', default=['//...'])],
     env=bazelBinEnv))
 
 goKytheSteps = util.BuildFactory()
@@ -154,15 +153,7 @@ c['builders'].append(
         name="bazel-0.17.1",
         workernames=["local-worker"],
         properties={'bazel_version': '0.17.1', 
-                    'bazel_flags': ['--config=remote', '-c', 'opt']},
-        locks=[build_lock.access('exclusive')],
-        factory=bazelKytheSteps))
-c['builders'].append(
-    util.BuilderConfig(
-        name="bazel-opt",
-        workernames=["local-worker"],
-        properties={'bazel_version': '0.17.1',
-                    'bazel_flags': ['--config=remote', '-c', 'opt']},
+                    'bazel_flags': ['--config=remote']},
         locks=[build_lock.access('exclusive')],
         factory=bazelKytheSteps))
 c['builders'].append(
@@ -171,7 +162,11 @@ c['builders'].append(
         workernames=["local-worker"],
         properties={'bazel_version': '0.17.1', 
                     'bazel_flags': ['--config=remote', '-c', 'opt', '--stamp'], 
-                    'bazel_target': '//kythe/release:release_test'},
+                    'bazel_targets': [
+                        '//...',
+                        '//kythe/docs/schema',
+                        '//kythe/release:release_test'
+                    ]},
         locks=[build_lock.access('exclusive')],
         factory=bazelKytheSteps))
 c['builders'].append(


### PR DESCRIPTION
The other asciidoc_with_verifier targets have their 'manual' tag removed so they are tested in all configurations.

The bazel-opt builder has been folded into the bazel-release builder.