### PR TITLE
Bazel extractor: Remove a redundant call to config.FixUnit.

### DIFF
--- a/kythe/go/extractors/bazel/extractor.go
+++ b/kythe/go/extractors/bazel/extractor.go
@@ -168,8 +168,6 @@ func (c *Config) ExtractToFile(ctx context.Context, info *ActionInfo, w *kzip.Wr
 	})
 	if err != nil {
 		return "", err
-	} else if err := c.fixup(cu); err != nil {
-		return "", err
 	}
 	return w.AddUnit(cu, nil)
 }


### PR DESCRIPTION
The underlying extraction machinery already invokes the fixup, so it is not
necessary to repeat it when extracting to a file. It is harmess apart from
being wasteful of resources to do so as long as the fixup is idempotent -- but
since that is not required, so don't (unintentionally) rely on it.