### PR TITLE
Use filepath.Dir & filepath.Base instead of filepath.Split.

### DIFF
--- a/kythe/go/extractors/config/runextractor/backup/backup.go
+++ b/kythe/go/extractors/config/runextractor/backup/backup.go
@@ -53,7 +53,8 @@ func New(orig string) (*File, error) {
 	}
 	defer f.Close()
 
-	dir, base := filepath.Split(orig)
+	dir := filepath.Dir(orig)
+	base := filepath.Base(orig)
 	tf, err := ioutil.TempFile(dir, base+".bkup")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Specifically to avoid #3051 we need to make sure we get a "." for the
local directory instead of "", because `ioutil.TempFile` will helpfully
prepend /tmp if you pass "" to dir.