### PR TITLE
Add a data dep on extractor runtime dep docker image.

### DIFF
--- a/kythe/go/extractors/config/BUILD
+++ b/kythe/go/extractors/config/BUILD
@@ -8,6 +8,9 @@ go_library(
         "config_parser.go",
         "extractor.go",
     ],
+    data = [
+        "//kythe/java/com/google/devtools/kythe/extractors/java/artifacts",
+    ],
     deps = [
         "//kythe/go/extractors/config/default/mvn",
         "//kythe/proto:extraction_config_go_proto",


### PR DESCRIPTION
I foresee problems importing this, but worth a shot because it'll avoid bugs during dev of the form "but I fixed this and it's still broken, why?".