### PR TITLE
Bazel extractor: Avoid re-recording input files already added.

### DIFF
--- a/kythe/go/extractors/bazel/extractor.go
+++ b/kythe/go/extractors/bazel/extractor.go
@@ -283,7 +283,9 @@ func (c *Config) classifyInputs(info *ActionInfo, unit *apb.CompilationUnit) []s
 	for _, in := range info.Inputs {
 		path, ok := c.checkInput(in)
 		if ok {
-			inputs.Add(path)
+			if !inputs.Add(path) {
+				continue // don't re-add files we've already seen
+			}
 			if c.isSource(path) {
 				sourceFiles.Add(path)
 				c.logPrintf("Matched source file from inputs: %q", path)

--- a/kythe/go/extractors/bazel/extractor_test.go
+++ b/kythe/go/extractors/bazel/extractor_test.go
@@ -62,7 +62,7 @@ var (
 	}
 	si = &xapb.SpawnInfo{
 		Argument:   []string{"cc", "-o", testOutput, "-c", "2.src", "4.src"},
-		InputFile:  []string{"1.dep", "2.src", "3.dep", "4.src"},
+		InputFile:  []string{"1.dep", "2.src", "3.dep", "1.dep", "4.src"},
 		OutputFile: []string{testOutput, "garbage"},
 		Variable: []*xapb.EnvironmentVariable{{
 			Name:  proto.String("PATH"),
@@ -140,7 +140,7 @@ func (r *results) checkValues(t *testing.T, cu *apb.CompilationUnit) {
 	wantInfo := &ActionInfo{ // N.B.: Values prior to filtering!
 		Target:    testTarget,
 		Arguments: []string{"cc", "-o", testOutput, "-c", "2.src", "4.src"},
-		Inputs:    []string{"1.dep", "2.src", "3.dep", "4.src"},
+		Inputs:    []string{"1.dep", "1.dep", "2.src", "3.dep", "4.src"},
 		Outputs:   []string{testOutput, "garbage"},
 		Environment: map[string]string{
 			"PATH":  "p1:p2",


### PR DESCRIPTION
When processing input files, filters may re-introduce files that were already
examined. Prior to this commit, this has two downsides: One, it's redundant
(which, though harmless, is wasteful), and two it can result in entries that do
not get correctly updated (which is incorrect).

Verify that we only add a new required_input for new file paths, and update the
tests to ensure this gets checked.