### PR TITLE
Rename extract_kindex to extract_kzip.

### DIFF
--- a/kythe/go/extractors/bazel/extractors.bzl
+++ b/kythe/go/extractors/bazel/extractors.bzl
@@ -29,7 +29,7 @@ def kindex_extractor(
         scoped = True):
     """This macro creates extra_action and action_listener for kindex.
 
-    This macro expands to an extra action listener that invokes extract_kindex
+    This macro expands to an extra action listener that invokes extract_kzip
     on matching spawn actions to produce a Kythe compilation record in .kzip
     format.
 
@@ -55,7 +55,7 @@ def kindex_extractor(
         fail("The 'corpus' attribute must be non-empty")
 
     xa_name = name + "_extra_action"
-    xa_tool = "//kythe/go/extractors/cmd/bazel:extract_kindex"
+    xa_tool = "//kythe/go/extractors/cmd/bazel:extract_kzip"
     xa_output = "$(ACTION_ID).%s.kzip" % language
     xa_args = {
         "extra_action": "$(EXTRA_ACTION_FILE)",

--- a/kythe/go/extractors/cmd/bazel/BUILD
+++ b/kythe/go/extractors/cmd/bazel/BUILD
@@ -8,13 +8,13 @@ filegroup(
 )
 
 filegroup(
-    name = "extract_kindex",
-    srcs = ["//kythe/go/extractors/cmd/bazel/extract_kindex"],
+    name = "extract_kzip",
+    srcs = ["//kythe/go/extractors/cmd/bazel/extract_kzip"],
 )
 
 # An action listener that attaches the Go extractor action to Go compilations.
 action_listener(
-    name = "extract_kindex_go",
+    name = "extract_kzip_go",
     extra_actions = [":extra_action"],
     mnemonics = ["GoCompile"],
     visibility = ["//visibility:public"],
@@ -25,10 +25,10 @@ extra_action(
     cmd = ("$(location :bazel_go_extractor)" +
            " -corpus kythe.io" +
            " $(EXTRA_ACTION_FILE)" +
-           " $(output $(ACTION_ID).go.kindex)" +
+           " $(output $(ACTION_ID).go.kzip)" +
            " $(location :govnames.json)"),
     data = [":govnames.json"],
-    out_templates = ["$(ACTION_ID).go.kindex"],
+    out_templates = ["$(ACTION_ID).go.kzip"],
     tools = [":bazel_go_extractor"],
 )
 

--- a/kythe/go/extractors/cmd/bazel/extract_kzip/BUILD
+++ b/kythe/go/extractors/cmd/bazel/extract_kzip/BUILD
@@ -3,8 +3,8 @@ load("//tools:build_rules/shims.bzl", "go_binary")
 package(default_visibility = ["//kythe:default_visibility"])
 
 go_binary(
-    name = "extract_kindex",
-    srcs = ["extract_kindex.go"],
+    name = "extract_kzip",
+    srcs = ["extract_kzip.go"],
     deps = [
         "//kythe/go/extractors/bazel",
         "//kythe/go/extractors/bazel/extutil",

--- a/kythe/go/extractors/cmd/bazel/extract_kzip/extract_kzip.go
+++ b/kythe/go/extractors/cmd/bazel/extract_kzip/extract_kzip.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Program extract_kindex implements a Bazel extra action that captures a Kythe
+// Program extract_kzip implements a Bazel extra action that captures a Kythe
 // compilation record for a "spawn" action.
 package main
 


### PR DESCRIPTION
This tool still knows how to write .kindex files if requested, but eventually
that feature will be removed.