### PR TITLE
Bootstrap JVM extractor details messages

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/BUILD
@@ -28,5 +28,6 @@ java_library(
         "@com_beust_jcommander//jar",
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java_util",
     ],
 )

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/JvmExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/JvmExtractor.java
@@ -31,6 +31,7 @@ import com.google.devtools.kythe.proto.Java.JarDetails;
 import com.google.devtools.kythe.proto.Java.JarEntryDetails;
 import com.google.devtools.kythe.proto.Storage.VName;
 import com.google.protobuf.Any;
+import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -51,6 +52,12 @@ public class JvmExtractor {
   public static final String BUILD_DETAILS_URL = "kythe.io/proto/kythe.proto.BuildDetails";
   public static final String JAR_DETAILS_URL = "kythe.io/proto/kythe.proto.JarDetails";
   public static final String JAR_ENTRY_DETAILS_URL = "kythe.io/proto/kythe.proto.JarEntryDetails";
+
+  public static final JsonFormat.TypeRegistry JSON_TYPE_REGISTRY =
+      JsonFormat.TypeRegistry.newBuilder()
+          .add(JarDetails.getDescriptor())
+          .add(BuildDetails.getDescriptor())
+          .build();
 
   /**
    * Returns a JVM {@link CompilationDescription} for the {@code .jar}/{@code .class} file paths

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/JvmExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/JvmExtractor.java
@@ -56,6 +56,7 @@ public class JvmExtractor {
   public static final JsonFormat.TypeRegistry JSON_TYPE_REGISTRY =
       JsonFormat.TypeRegistry.newBuilder()
           .add(JarDetails.getDescriptor())
+          .add(JarEntryDetails.getDescriptor())
           .add(BuildDetails.getDescriptor())
           .build();
 

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
@@ -23,6 +23,7 @@ java_binary(
         "//kythe/java/com/google/devtools/kythe/extractors/jvm:jvm_extractor",
         "//kythe/java/com/google/devtools/kythe/extractors/shared",
         "//kythe/java/com/google/devtools/kythe/platform/indexpack",
+        "//kythe/java/com/google/devtools/kythe/util:json",
         "//third_party/bazel:extra_actions_base_java_proto",
         "//third_party/guava",
         "@com_google_protobuf//:protobuf_java",

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BazelJvmExtractor.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BazelJvmExtractor.java
@@ -26,6 +26,7 @@ import com.google.devtools.kythe.extractors.jvm.JvmExtractor.Options;
 import com.google.devtools.kythe.extractors.shared.CompilationDescription;
 import com.google.devtools.kythe.extractors.shared.ExtractionException;
 import com.google.devtools.kythe.extractors.shared.IndexInfoUtils;
+import com.google.devtools.kythe.util.JsonUtil;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.ExtensionRegistry;
 import java.io.File;
@@ -45,6 +46,8 @@ import java.util.List;
 public class BazelJvmExtractor {
 
   public static void main(String[] args) throws IOException, ExtractionException {
+    JsonUtil.usingTypeRegistry(JvmExtractor.JSON_TYPE_REGISTRY);
+
     if (args.length != 2 && args.length != 3) {
       System.err.println(
           "Usage: bazel_jvm_extractor extra-action-file output-file [vnames-config]");


### PR DESCRIPTION
Load in the JVM extractor's detail messages so the kzip can write out files. If you don't do this, you'll get an error message like java.lang.RuntimeException: com.google.protobuf.InvalidProtocolBufferException: Cannot find type for url: kythe.io/proto/kythe.proto.JarEntryDetails