### PR TITLE
Only replace Decl TSI if the location-aware type is an undeduced type

### DIFF
--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -980,6 +980,22 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "function_knr_defn",
+    srcs = ["function/function_knr_defn.c"],
+    std = "gnu89",
+    tags = ["function"],
+)
+
+cc_indexer_test(
+    name = "function_picky_types",
+    srcs = ["function/function_picky_types.c"],
+    convert_marked_source = True,
+    ignore_dups = True,
+    std = "gnu89",
+    tags = ["function"],
+)
+
+cc_indexer_test(
     name = "function_lambda",
     srcs = ["function/function_lambda.cc"],
     ignore_dups = True,

--- a/kythe/cxx/indexer/cxx/testdata/function/function_knr_defn.c
+++ b/kythe/cxx/indexer/cxx/testdata/function/function_knr_defn.c
@@ -1,0 +1,8 @@
+// Verifies that functions with K&R style definitions are parsed correctly.
+
+//- @fn defines/binding FnDefn
+//- FnDefn param.0 ArgDefn
+void fn(A)
+//- @A defines/binding ArgDefn
+  int A;
+{ }

--- a/kythe/cxx/indexer/cxx/testdata/function/function_picky_types.c
+++ b/kythe/cxx/indexer/cxx/testdata/function/function_picky_types.c
@@ -1,0 +1,16 @@
+// Verify that a crash introduced in the indexer by overzealous
+// type replacement in DeclaratorDecls isn't reintroduced.
+
+//- @_F defines/binding FileStruct
+struct _F;
+//- @FILE defines/binding FileAlias
+typedef struct _F FILE;
+typedef __SIZE_TYPE__ size_t;
+
+//- @fread defines/binding FreadFn
+//- FreadFn code FCRoot
+//- FCRoot child.0 FCSize
+//- FCSize.kind "TYPE"
+extern size_t fread (void *__restrict __ptr, size_t __size,
+                     //- @FILE ref FileAlias
+		     size_t __n, FILE *__restrict __stream);


### PR DESCRIPTION
We were overzealous before and triggered an assert() in clang in production.  This didn't manifest in tests because we build llvm with -DNDEBUG, bypassing the assert.

We are also triggering a segfault in production, but not with the included test.  It appears to be the same problem, but optimization and lack of NDEBUG makes it harder to tell why/where that failure is occurring.  It should be the same one (or at least related), but it's hard to tell for certain.