### PR TITLE
Fix building @io_kythe//third_party/llvm/src:clang_builtin_headers

### DIFF
--- a/third_party/llvm/src/BUILD
+++ b/third_party/llvm/src/BUILD
@@ -1,5 +1,7 @@
 licenses(["notice"])
 
+load("//tools:build_rules/cc_resources.bzl", "gendir")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
@@ -42,6 +44,6 @@ cc_library(
         "-Wno-non-virtual-dtor",
         "-Wno-unused-variable",
         "-Wno-implicit-fallthrough",
-        "-I$(GENDIR)/third_party/llvm",
+        "-I" + gendir() + "/third_party/llvm",
     ],
 )

--- a/tools/build_rules/cc_resources.bzl
+++ b/tools/build_rules/cc_resources.bzl
@@ -15,3 +15,11 @@ def cc_resources(name, data):
         srcs = data,
         cmd = cmd,
     )
+
+# Returns the generated files directory root.
+#
+# Note: workaround for https://github.com/bazelbuild/bazel/issues/4463.
+def gendir():
+    if native.repository_name() == "@":
+        return "$(GENDIR)"
+    return "$(GENDIR)/external/" + native.repository_name().lstrip("@")


### PR DESCRIPTION
When built as part of an external repository, the generated files directory needs to be updated with the repository name.