### PR TITLE
Riegeli: fix seeking in files with metadata record

### DIFF
--- a/kythe/go/util/riegeli/reader.go
+++ b/kythe/go/util/riegeli/reader.go
@@ -476,7 +476,7 @@ func (c *chunkReader) SeekToChunkContaining(pos int64) error {
 
 		nextChunk := c.position + chunkHeaderSize + int64(h.DataSize) + int64(paddingSize(int(c.position), h))
 		if pos < nextChunk {
-			// We've at the chunk containing the desired position.
+			// We're at the chunk containing the desired position.
 			break
 		} else if err := c.r.Seek(nextChunk); err != nil {
 			return fmt.Errorf("error seeking to next chunk: %v", err)

--- a/kythe/go/util/riegeli/riegeli_test.go
+++ b/kythe/go/util/riegeli/riegeli_test.go
@@ -232,7 +232,7 @@ func TestEmptyRecord(t *testing.T) {
 
 func TestReaderSeekRecords(t *testing.T) {
 	const N = 1e4
-	buf := writeStrings(t, nil, N)
+	buf := writeStrings(t, &WriterOptions{}, N)
 
 	rd := NewReadSeeker(bytes.NewReader(buf.Bytes()))
 	lastIndex := int64(-1)
@@ -272,7 +272,7 @@ func TestReaderSeekRecords(t *testing.T) {
 
 func TestReaderSeekKnownPositions(t *testing.T) {
 	const N = 1e4
-	buf := writeStrings(t, nil, N)
+	buf := writeStrings(t, &WriterOptions{}, N)
 
 	rd := NewReadSeeker(bytes.NewReader(buf.Bytes()))
 	lastIndex := int64(-1)
@@ -312,7 +312,7 @@ func TestReaderSeekKnownPositions(t *testing.T) {
 
 func TestReaderSeekAllPositions(t *testing.T) {
 	const N = 1e4
-	buf := writeStrings(t, nil, N)
+	buf := writeStrings(t, &WriterOptions{}, N)
 
 	rd := NewReadSeeker(bytes.NewReader(buf.Bytes()))
 


### PR DESCRIPTION
Seeking through the chunks in a block needs to include seeking past the data for each chunk.