### PR TITLE
Implement StandardJavaFileManager#setLocationsFromPaths

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/UsageAsInputReportingFileManager.java
@@ -20,7 +20,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -142,6 +144,18 @@ class UsageAsInputReportingFileManager extends ForwardingJavaFileManager<Standar
   @Override
   public Iterable<? extends File> getLocation(Location location) {
     return fileManager.getLocation(location);
+  }
+
+  // TODO(schroederc): @Override; method added in JDK9
+  public void setLocationFromPaths(Location location, Collection<? extends Path> paths)
+      throws IOException {
+    try {
+      StandardJavaFileManager.class
+          .getMethod("setLocationFromPaths", Location.class, Collection.class)
+          .invoke(fileManager, location, paths);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
   }
 
   // StandardJavaFileManager doesn't like it when it's asked about a JavaFileObject

--- a/kythe/java/com/google/devtools/kythe/platform/java/filemanager/JavaFileStoreBasedFileManager.java
+++ b/kythe/java/com/google/devtools/kythe/platform/java/filemanager/JavaFileStoreBasedFileManager.java
@@ -18,8 +18,11 @@ package com.google.devtools.kythe.platform.java.filemanager;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -200,6 +203,18 @@ public class JavaFileStoreBasedFileManager
   @Override
   public void setLocation(Location location, Iterable<? extends File> path) throws IOException {
     fileManager.setLocation(location, path);
+  }
+
+  // TODO(schroederc): @Override; method added in JDK9
+  public void setLocationFromPaths(Location location, Collection<? extends Path> paths)
+      throws IOException {
+    try {
+      StandardJavaFileManager.class
+          .getMethod("setLocationFromPaths", Location.class, Collection.class)
+          .invoke(fileManager, location, paths);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("setLocationFromPaths called by unsupported Java version", e);
+    }
   }
 
   public static Kind getKind(String name) {


### PR DESCRIPTION
This override is necessary in Java 9 and later to fully support the `--release` option.  Reflection is used to allow us to continue to support Java 8.