### PR TITLE
Migrate javac_extractor to use ambient langtools

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/README.md
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/README.md
@@ -19,7 +19,7 @@ the project.
 # Extra action invokes /opt/kythe/extractors/bazel_java_extractor.jar
 extra_action(
     name = "extractor",
-    cmd = ("java -Xbootclasspath/p:/opt/kythe/extractors/bazel_java_extractor.jar " +
+    cmd = ("java -Xbootclasspath/p:third_party/javac/javac*.jar " +
            "com.google.devtools.kythe.extractors.java.bazel.JavaExtractor " +
            "$(EXTRA_ACTION_FILE) $(output $(ACTION_ID).java.kindex) $(location :vnames.json)"),
     data = [":vnames.json"],

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -20,7 +20,9 @@
 # KYTHE_OUTPUT_DIRECTORY set to understand where the root of the compiled source
 # repository is and where to put the resulting .kindex files, respectively.
 #
-# This script assumes a usable java binary is on $PATH.
+# This script assumes a usable java binary is on $PATH or in $JAVA_HOME.
+# Runtime options (e.g -Xbootclasspath/p:)can be passed to `java` with the
+# $KYTHE_JAVA_RUNTIME_OPTIONS environment variable.
 #
 # This script is meant as a replacement for $JAVA_HOME/bin/javac.  It assumes
 # the true javac binary is in the same directory as itself and named
@@ -40,8 +42,10 @@
 
 export TMPDIR="${TMPDIR:-/tmp}"
 
-if [[ -z "$JAVABIN" ]]; then
+if [[ -z "$JAVA_HOME" ]]; then
   readonly JAVABIN="$(which java)"
+else
+  readonly JAVABIN="$JAVA_HOME/bin/java"
 fi
 if [[ -z "$REAL_JAVAC" ]]; then
   readonly REAL_JAVAC="$(dirname "$(readlink -e "$0")")/javac.real"
@@ -65,7 +69,8 @@ if [[ -n "$DOCKER_CLEANUP" ]]; then
   trap cleanup EXIT ERR INT
 fi
 
-"$JAVABIN" -jar "$JAVAC_EXTRACTOR_JAR" "$@" \
+"$JAVABIN" "${KYTHE_JAVA_RUNTIME_OPTIONS[@]}" \
+  -jar "$JAVAC_EXTRACTOR_JAR" "$@" \
   1>>"$TMPDIR"/javac-extractor.out \
   2>>"$TMPDIR"/javac-extractor.err
 if [[ -z "$KYTHE_EXTRACT_ONLY" ]]; then

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh
@@ -40,6 +40,9 @@
 
 export TMPDIR="${TMPDIR:-/tmp}"
 
+if [[ -z "$JAVABIN" ]]; then
+  readonly JAVABIN="$(which java)"
+fi
 if [[ -z "$REAL_JAVAC" ]]; then
   readonly REAL_JAVAC="$(dirname "$(readlink -e "$0")")/javac.real"
 fi
@@ -62,9 +65,9 @@ if [[ -n "$DOCKER_CLEANUP" ]]; then
   trap cleanup EXIT ERR INT
 fi
 
-java -Xbootclasspath/p:"$JAVAC_EXTRACTOR_JAR" \
-     -jar "$JAVAC_EXTRACTOR_JAR" \
-     "$@" >>"$TMPDIR"/javac-extractor.out 2>> "$TMPDIR"/javac-extractor.err
+"$JAVABIN" -jar "$JAVAC_EXTRACTOR_JAR" "$@" \
+  1>>"$TMPDIR"/javac-extractor.out \
+  2>>"$TMPDIR"/javac-extractor.err
 if [[ -z "$KYTHE_EXTRACT_ONLY" ]]; then
   "$REAL_JAVAC" "$@"
 fi

--- a/kythe/java/com/google/devtools/kythe/util/BUILD
+++ b/kythe/java/com/google/devtools/kythe/util/BUILD
@@ -69,3 +69,13 @@ java_library(
         "//kythe/proto:common_java_proto",
     ],
 )
+
+# Sources used to test Java extraction in //kythe/release:release_test.
+filegroup(
+    name = "test_srcs",
+    srcs = [
+        "DeleteRecursively.java",
+        "PositionMappings.java",
+        "Span.java",
+    ],
+)

--- a/kythe/release/BUILD
+++ b/kythe/release/BUILD
@@ -75,7 +75,7 @@ genrule(
     tags = ["manual"],
     tools = [
         "package_release.sh",
-        "//kythe/go/platform/tools/shasum_tool"
+        "//kythe/go/platform/tools/shasum_tool",
     ],
 )
 
@@ -92,18 +92,22 @@ sh_test(
     name = "release_test",
     timeout = "short",
     srcs = ["release_test.sh"],
+    args = [
+        # Since go binaries are not located at their bazel target path (//go/binary
+        # might be in bazel-out/go/binary/host/text/binary), pass the actual
+        # location of the binary directly to the shell script.
+        "$(location //kythe/go/platform/tools/shasum_tool)",
+    ],
     data = [
         ":release",
         "//kythe/go/platform/tools/shasum_tool",
+        "//kythe/java/com/google/devtools/kythe/util:test_srcs",
         "//kythe/testdata:entries",
         "//kythe/testdata:test.kindex",
         "//third_party/guava",
+        "//third_party/javac:javac_jar",
         "@com_github_stedolan_jq//:jq",
     ],
-    # Since go binaries are not located at their bazel target path (//go/binary
-    # might be in bazel-out/go/binary/host/text/binary), pass the actual
-    # location of the binary directly to the shell script.
-    args = ["$(location //kythe/go/platform/tools/shasum_tool)"],
     tags = [
         "local",
         "manual",

--- a/kythe/release/README.md
+++ b/kythe/release/README.md
@@ -139,7 +139,7 @@ Read `extractors/javac-wrapper.sh` for more details on its usage.
 
     mkdir -p "$KYTHE_OUTPUT_DIRECTORY"
 
-    java -Xbootclasspath/p:extractors/javac_extractor.jar \
+    java -Xbootclasspath/p:third_party/javac/javac*.jar \
       -jar extractors/javac_extractor.jar \
       -cp "${$(find third_party -name '*.jar' -printf '%p:')%:}" \
       $(find src/main -name '*.java')

--- a/kythe/web/site/examples.md
+++ b/kythe/web/site/examples.md
@@ -32,10 +32,10 @@ export KYTHE_VNAMES="$PWD/kythe/data/vnames.json"         # Optional: VNames con
 mkdir -p "$KYTHE_OUTPUT_DIRECTORY"
 
 # Extract a Java compilation
-# java -Xbootclasspath/p:/opt/kythe/extractors/javac_extractor.jar \
+# java -Xbootclasspath/p:third_party/javac/javac*.jar \
 #   com.google.devtools.kythe.extractors.java.standalone.Javac8Wrapper \
 #   <javac_arguments>
-java -Xbootclasspath/p:/opt/kythe/extractors/javac_extractor.jar \
+java -Xbootclasspath/p:third_party/javac/javac*.jar \
   com.google.devtools.kythe.extractors.java.standalone.Javac8Wrapper \
   kythe/java/com/google/devtools/kythe/common/*.java
 
@@ -97,16 +97,16 @@ then be stored in a [GraphStore]({{site.baseurl}}/docs/kythe-storage.html).
   --index_pack=.kythe_indexpack f0dcfd6fe90919e957f635ec568a793554905012aea803589cdbec625d72de4d > entries
 
 # Indexing a Java compilation
-# java -Xbootclasspath/p:/opt/kythe/indexers/java_indexer.jar \
+# java -Xbootclasspath/p:third_party/javac/javac*.jar \
 #   com.google.devtools.kythe.analyzers.java.JavaIndexer \
 #   <kindex-file> > entries
-java -Xbootclasspath/p:/opt/kythe/indexers/java_indexer.jar \
+java -Xbootclasspath/p:third_party/javac/javac*.jar \
   com.google.devtools.kythe.analyzers.java.JavaIndexer \
   $PWD/.kythe_compilations/java/kythe_java_com_google_devtools_kythe_analyzers_java_analyzer.java.kindex > entries
-# java -Xbootclasspath/p:/opt/kythe/indexers/java_indexer.jar \
+# java -Xbootclasspath/p:third_party/javac/javac*.jar \
 #   com.google.devtools.kythe.analyzers.java.JavaIndexer \
 #   --index_path=<root> <unit-hash> > entries
-java -Xbootclasspath/p:/opt/kythe/indexers/java_indexer.jar \
+java -Xbootclasspath/p:third_party/javac/javac*.jar \
   com.google.devtools.kythe.analyzers.java.JavaIndexer \
   --index_pack=$PWD/.kythe_indexpack b3759d74b6ee8ba97312cf8b1b47c4263504a56ca9ab63e8f3af98298ccf9fd6 > entries
 # NOTE: https://kythe.io/phabricator/T40 -- the Java indexer should not be run in

--- a/third_party/javac/BUILD
+++ b/third_party/javac/BUILD
@@ -10,6 +10,7 @@ filegroup(
 java_import(
     name = "javac",
     jars = ["javac-9-dev-r4023-1.jar"],
+    neverlink = True,
 )
 
 filegroup(

--- a/third_party/javac/BUILD
+++ b/third_party/javac/BUILD
@@ -9,8 +9,13 @@ filegroup(
 
 java_import(
     name = "javac",
-    jars = ["javac-9-dev-r4023-1.jar"],
+    jars = [":javac_jar"],
     neverlink = True,
+)
+
+filegroup(
+    name = "javac_jar",
+    srcs = ["javac-9-dev-r4023-1.jar"],
 )
 
 filegroup(


### PR DESCRIPTION
Part of #3075.

This removes our hard-coded usage of `-Xbootclasspath/p` and allows the `javac-wrapper.sh` to be version-agnostic.  When running on JRE 8, the `-Xbootclasspath/p` flag can be passed using the `KYTHE_JAVA_RUNTIME_OPTIONS` environment variable.