### PR TITLE
Don't crash if we try to write the same file to a kzip more than once

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/BUILD
@@ -6,9 +6,10 @@ java_library(
         "KZip.java",
         "KZipException.java",
         "KZipReader.java",
-        "KZipWriter.java"
+        "KZipWriter.java",
     ],
     deps = [
+        "//kythe/java/com/google/devtools/kythe/common:flogger",
         "//kythe/java/com/google/devtools/kythe/util:json",
         "//kythe/proto:analysis_java_proto",
         "//third_party/guava",

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
@@ -97,7 +97,7 @@ public final class KZipWriter implements KZip.Writer {
       output.write(data);
       output.closeEntry();
     } else {
-      logger.atWarning().log("Warning: Already wrote " + path + " to kzip.");
+      logger.atWarning().log("Warning: Already wrote %s to kzip.", path);
     }
   }
 

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
@@ -15,6 +15,7 @@
  */
 package com.google.devtools.kythe.platform.kzip;
 
+import com.google.common.flogger.FluentLogger;
 import com.google.devtools.kythe.proto.Analysis;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -28,6 +29,7 @@ import java.util.zip.ZipOutputStream;
 
 /** Write a kzip file. */
 public final class KZipWriter implements KZip.Writer {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static final String ROOT_PREFIX = "root/";
   private final ZipOutputStream output;
@@ -94,7 +96,7 @@ public final class KZipWriter implements KZip.Writer {
       output.write(data);
       output.closeEntry();
     } else {
-      System.err.println("Warning: Already wrote " + path + " to kzip.");
+      logger.atWarning().log("Warning: Already wrote " + path + " to kzip.");
     }
   }
 

--- a/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
+++ b/kythe/java/com/google/devtools/kythe/platform/kzip/KZipWriter.java
@@ -35,7 +35,8 @@ public final class KZipWriter implements KZip.Writer {
   private final ZipOutputStream output;
   private final Gson gson;
 
-  // We may
+  // We store our own set of paths written, analogous to ZipOutputWriter.names, so that we avoid
+  // raising exceptions by writing duplicates.
   private final Set<String> pathsWritten;
 
   public KZipWriter(File file) throws IOException {


### PR DESCRIPTION
It looks like we may see the same file multiple times during extraction. If we try to add the file to the zip again, the zip library will throw a generic zip exception. We can avoid this situation by just not appending a file if we know we have already added it to the zip.