### PR TITLE
Begin migrating external repository definitions to importable WORKSPACE function

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,9 @@ workspace(name = "io_kythe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 load("//:version.bzl", "check_version")
+load("//:external.bzl", "kythe_dependencies")
+
+kythe_dependencies()
 
 # Check that the user has a version between our minimum supported version of
 # Bazel and our maximum supported version of Bazel.
@@ -29,7 +32,7 @@ bind(
 
 http_archive(
     name = "org_libmemcached_libmemcached",
-    build_file = "@//third_party:libmemcached.BUILD",
+    build_file = "@io_kythe//third_party:libmemcached.BUILD",
     sha256 = "e22c0bb032fde08f53de9ffbc5a128233041d9f33b5de022c0978a2149885f82",
     strip_prefix = "libmemcached-1.0.18",
     url = "https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz",
@@ -50,9 +53,14 @@ bind(
     actual = "@com_google_code_gson_gson//jar",
 )
 
+bind(
+    name = "zlib",  # required by @com_google_protobuf
+    actual = "@net_zlib//:zlib",
+)
+
 http_archive(
     name = "se_haxx_curl",
-    build_file = "@//third_party:curl.BUILD",
+    build_file = "@io_kythe//third_party:curl.BUILD",
     sha256 = "ff3e80c1ca6a068428726cd7dd19037a47cc538ce58ef61c59587191039b2ca6",
     strip_prefix = "curl-7.49.1",
     urls = [
@@ -62,23 +70,8 @@ http_archive(
 )
 
 http_archive(
-    name = "net_zlib",
-    build_file = "@//third_party:zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = [
-        "https://zlib.net/zlib-1.2.11.tar.gz",
-    ],
-)
-
-bind(
-    name = "zlib",  # required by @com_google_protobuf
-    actual = "@net_zlib//:zlib",
-)
-
-http_archive(
     name = "org_libzip",
-    build_file = "@//third_party:libzip.BUILD",
+    build_file = "@io_kythe//third_party:libzip.BUILD",
     sha256 = "a5d22f0c87a2625450eaa5e10db18b8ee4ef17042102d04c62e311993a2ba363",
     strip_prefix = "libzip-rel-1-5-1",
     urls = [
@@ -148,7 +141,7 @@ http_archive(
 
 http_archive(
     name = "com_github_google_glog",
-    build_file = "@//third_party:googlelog.BUILD",
+    build_file = "@io_kythe//third_party:googlelog.BUILD",
     sha256 = "ce61883437240d650be724043e8b3c67e257690f876ca9fd53ace2a791cfea6c",
     strip_prefix = "glog-bac8811710c77ac3718be1c4801f43d37c1aea46",
     url = "https://github.com/google/glog/archive/bac8811710c77ac3718be1c4801f43d37c1aea46.zip",
@@ -156,7 +149,7 @@ http_archive(
 
 http_archive(
     name = "com_github_tencent_rapidjson",
-    build_file = "@//third_party:rapidjson.BUILD",
+    build_file = "@io_kythe//third_party:rapidjson.BUILD",
     sha256 = "8e00c38829d6785a2dfb951bb87c6974fa07dfe488aa5b25deec4b8bc0f6a3ab",
     strip_prefix = "rapidjson-1.1.0",
     url = "https://github.com/Tencent/rapidjson/archive/v1.1.0.zip",
@@ -164,7 +157,7 @@ http_archive(
 
 http_archive(
     name = "com_github_stedolan_jq",
-    build_file = "@//third_party:jq.BUILD",
+    build_file = "@io_kythe//third_party:jq.BUILD",
     sha256 = "998c41babeb57b4304e65b4eb73094279b3ab1e63801b6b4bddd487ce009b39d",
     strip_prefix = "jq-1.4",
     url = "https://github.com/stedolan/jq/releases/download/jq-1.4/jq-1.4.tar.gz",
@@ -172,7 +165,7 @@ http_archive(
 
 http_archive(
     name = "com_github_google_snappy",
-    build_file = "@//third_party:snappy.BUILD",
+    build_file = "@io_kythe//third_party:snappy.BUILD",
     sha256 = "61e05a0295fd849072668b1f3494801237d809427cfe8fd014cda455036c3ef7",
     strip_prefix = "snappy-1.1.7",
     url = "https://github.com/google/snappy/archive/1.1.7.zip",
@@ -180,34 +173,16 @@ http_archive(
 
 http_archive(
     name = "com_github_google_leveldb",
-    build_file = "@//third_party:leveldb.BUILD",
+    build_file = "@io_kythe//third_party:leveldb.BUILD",
     sha256 = "5b2bd7a91489095ad54bb81ca6544561025b48ec6d19cc955325f96755d88414",
     strip_prefix = "leveldb-1.20",
     url = "https://github.com/google/leveldb/archive/v1.20.zip",
 )
 
 maven_jar(
-    name = "com_google_code_gson_gson",
-    artifact = "com.google.code.gson:gson:2.8.5",
-    sha1 = "f645ed69d595b24d4cf8b3fbb64cc505bede8829",
-)
-
-maven_jar(
-    name = "com_google_guava_guava",
-    artifact = "com.google.guava:guava:25.1-jre",
-    sha1 = "6c57e4b22b44e89e548b5c9f70f0c45fe10fb0b4",
-)
-
-maven_jar(
     name = "junit_junit",
     artifact = "junit:junit:4.12",
     sha1 = "2973d150c0dc1fefe998f834810d68f278ea58ec",
-)
-
-maven_jar(
-    name = "com_google_re2j_re2j",
-    artifact = "com.google.re2j:re2j:1.2",
-    sha1 = "4361eed4abe6f84d982cbb26749825f285996dd2",
 )
 
 maven_jar(
@@ -226,12 +201,6 @@ maven_jar(
     name = "com_googlecode_java_diff_utils",
     artifact = "com.googlecode.java-diff-utils:diffutils:1.3.0",
     sha1 = "7e060dd5b19431e6d198e91ff670644372f60fbd",
-)
-
-maven_jar(
-    name = "com_google_code_findbugs_jsr305",
-    artifact = "com.google.code.findbugs:jsr305:3.0.1",
-    sha1 = "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
 )
 
 maven_jar(
@@ -264,69 +233,13 @@ maven_jar(
     sha1 = "9e9cf7bc4b2a60efeb5f5581fe46d17c068e0777",
 )
 
-maven_jar(
-    name = "org_ow2_asm_asm",
-    artifact = "org.ow2.asm:asm:6.0",
-    sha1 = "bc6fa6b19424bb9592fe43bbc20178f92d403105",
-)
-
-maven_jar(
-    name = "com_google_errorprone_error_prone_annotations",
-    artifact = "com.google.errorprone:error_prone_annotations:2.3.1",
-    sha1 = "a6a2b2df72fd13ec466216049b303f206bd66c5d",
-)
-
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "5f3b0304cdf0c505ec9e5b3c4fc4a87b5ca21b13d8ecc780c97df3d1809b9ce6",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.1/rules_go-0.15.1.tar.gz"],
-)
-
-# Required by com_google_protobuf.
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "ca4e3b8e4da9266c3a9101c8f4704fe2e20eb5625b2a6a7d2d7d45e3dd4efffd",
-    strip_prefix = "bazel-skylib-0.5.0",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.zip"],
-)
-
-# proto_library, cc_proto_library, and java_proto_library rules implicitly
-# depend on @com_google_protobuf for protoc and proto runtimes.
-#
-# N.B. We have a near-clone of the protobuf BUILD file overriding upstream so
-# that we can set the unexported config variable to enable zlib. Without this,
-# protobuf silently yields link errors.
-# The most recent release (v3.6.0.1) lacks an fix for
-# https://github.com/google/protobuf/issues/4771, which we rely on in tests.
-# TODO(shahms): Update to the first release to include that fix.
-http_archive(
-    name = "com_google_protobuf",
-    build_file = "@//third_party:protobuf.BUILD",
-    sha256 = "08608786f26c2ae4e5ff854560289779314b60179b5df824836303e2c0fae407",
-    strip_prefix = "protobuf-964201af37f8a0009440a52a30a66317724a52c3",
-    urls = ["https://github.com/google/protobuf/archive/964201af37f8a0009440a52a30a66317724a52c3.zip"],
-)
-
 # A copy of the above archive because com_google_riegeli uses a non-standard name... (╯°□°)╯︵ ┻━┻
 http_archive(
     name = "protobuf_archive",
-    build_file = "@//third_party:protobuf.BUILD",
+    build_file = "@io_kythe//third_party:protobuf.BUILD",
     sha256 = "08608786f26c2ae4e5ff854560289779314b60179b5df824836303e2c0fae407",
     strip_prefix = "protobuf-964201af37f8a0009440a52a30a66317724a52c3",
     urls = ["https://github.com/google/protobuf/archive/964201af37f8a0009440a52a30a66317724a52c3.zip"],
-)
-
-http_archive(
-    name = "google_bazel_common",
-    strip_prefix = "bazel-common-e7580d1db7466e6c8403f7826b7558ea5e99bbfd",
-    urls = ["https://github.com/google/bazel-common/archive/e7580d1db7466e6c8403f7826b7558ea5e99bbfd.zip"],
-)
-
-git_repository(
-    name = "com_google_common_flogger",
-    commit = "f6071d2c5cd6c6c4f5fcd9f74bfec4ca972b0423",
-    # TODO(schroederc): remove usage of fork once https://github.com/google/flogger/pull/37 is closed
-    remote = "https://github.com/schroederc/flogger",
 )
 
 http_archive(
@@ -356,7 +269,7 @@ load("//tools:build_rules/shims.bzl", "go_repository")
 #                   https://github.com/bazelbuild/rules_go/issues/1533 is fixed
 new_git_repository(
     name = "go_protobuf",
-    build_file = "@//third_party/go:protobuf.BUILD",
+    build_file = "@io_kythe//third_party/go:protobuf.BUILD",
     commit = "b4deda0973fb4c70b50d226b1af49f3da59f5265",
     remote = "https://github.com/golang/protobuf.git",
 )

--- a/external.bzl
+++ b/external.bzl
@@ -1,6 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:maven_rules.bzl", "maven_jar")
 
 def maybe(repo_rule, name, **kwargs):
     """Defines a repository if it does not already exist.
@@ -35,42 +34,42 @@ def _java_dependencies():
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "com_google_code_gson_gson",
         artifact = "com.google.code.gson:gson:2.8.5",
         sha1 = "f645ed69d595b24d4cf8b3fbb64cc505bede8829",
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "com_google_guava_guava",
         artifact = "com.google.guava:guava:25.1-jre",
         sha1 = "6c57e4b22b44e89e548b5c9f70f0c45fe10fb0b4",
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "com_google_re2j_re2j",
         artifact = "com.google.re2j:re2j:1.2",
         sha1 = "4361eed4abe6f84d982cbb26749825f285996dd2",
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "com_google_code_findbugs_jsr305",
         artifact = "com.google.code.findbugs:jsr305:3.0.1",
         sha1 = "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "com_google_errorprone_error_prone_annotations",
         artifact = "com.google.errorprone:error_prone_annotations:2.3.1",
         sha1 = "a6a2b2df72fd13ec466216049b303f206bd66c5d",
     )
 
     maybe(
-        maven_jar,
+        native.maven_jar,
         name = "org_ow2_asm_asm",
         artifact = "org.ow2.asm:asm:6.0",
         sha1 = "bc6fa6b19424bb9592fe43bbc20178f92d403105",

--- a/external.bzl
+++ b/external.bzl
@@ -1,0 +1,120 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:maven_rules.bzl", "maven_jar")
+
+def maybe(repo_rule, name, **kwargs):
+    """Defines a repository if it does not already exist.
+    """
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)
+
+def _cc_dependencies():
+    maybe(
+        http_archive,
+        name = "net_zlib",
+        build_file = "@io_kythe//third_party:zlib.BUILD",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    )
+
+def _java_dependencies():
+    maybe(
+        # For @com_google_common_flogger
+        http_archive,
+        name = "google_bazel_common",
+        strip_prefix = "bazel-common-e7580d1db7466e6c8403f7826b7558ea5e99bbfd",
+        urls = ["https://github.com/google/bazel-common/archive/e7580d1db7466e6c8403f7826b7558ea5e99bbfd.zip"],
+    )
+    maybe(
+        git_repository,
+        name = "com_google_common_flogger",
+        commit = "f6071d2c5cd6c6c4f5fcd9f74bfec4ca972b0423",
+        # TODO(schroederc): remove usage of fork once https://github.com/google/flogger/pull/37 is closed
+        remote = "https://github.com/schroederc/flogger",
+    )
+
+    maybe(
+        maven_jar,
+        name = "com_google_code_gson_gson",
+        artifact = "com.google.code.gson:gson:2.8.5",
+        sha1 = "f645ed69d595b24d4cf8b3fbb64cc505bede8829",
+    )
+
+    maybe(
+        maven_jar,
+        name = "com_google_guava_guava",
+        artifact = "com.google.guava:guava:25.1-jre",
+        sha1 = "6c57e4b22b44e89e548b5c9f70f0c45fe10fb0b4",
+    )
+
+    maybe(
+        maven_jar,
+        name = "com_google_re2j_re2j",
+        artifact = "com.google.re2j:re2j:1.2",
+        sha1 = "4361eed4abe6f84d982cbb26749825f285996dd2",
+    )
+
+    maybe(
+        maven_jar,
+        name = "com_google_code_findbugs_jsr305",
+        artifact = "com.google.code.findbugs:jsr305:3.0.1",
+        sha1 = "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
+    )
+
+    maybe(
+        maven_jar,
+        name = "com_google_errorprone_error_prone_annotations",
+        artifact = "com.google.errorprone:error_prone_annotations:2.3.1",
+        sha1 = "a6a2b2df72fd13ec466216049b303f206bd66c5d",
+    )
+
+    maybe(
+        maven_jar,
+        name = "org_ow2_asm_asm",
+        artifact = "org.ow2.asm:asm:6.0",
+        sha1 = "bc6fa6b19424bb9592fe43bbc20178f92d403105",
+    )
+
+def _go_dependencies():
+    maybe(
+        http_archive,
+        name = "io_bazel_rules_go",
+        sha256 = "5f3b0304cdf0c505ec9e5b3c4fc4a87b5ca21b13d8ecc780c97df3d1809b9ce6",
+        urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.1/rules_go-0.15.1.tar.gz"],
+    )
+
+def kythe_dependencies():
+    """Defines external repositories for Kythe dependencies.
+
+    Call this once in your WORKSPACE file to load all @io_kythe dependencies.
+    """
+    _cc_dependencies()
+    _go_dependencies()
+    _java_dependencies()
+
+    # proto_library, cc_proto_library, and java_proto_library rules implicitly
+    # depend on @com_google_protobuf for protoc and proto runtimes.
+    #
+    # N.B. We have a near-clone of the protobuf BUILD file overriding upstream so
+    # that we can set the unexported config variable to enable zlib. Without this,
+    # protobuf silently yields link errors.
+    # The most recent release (v3.6.0.1) lacks an fix for
+    # https://github.com/google/protobuf/issues/4771, which we rely on in tests.
+    # TODO(shahms): Update to the first release to include that fix.
+    maybe(
+        http_archive,
+        name = "com_google_protobuf",
+        build_file = "@io_kythe//third_party:protobuf.BUILD",
+        sha256 = "08608786f26c2ae4e5ff854560289779314b60179b5df824836303e2c0fae407",
+        strip_prefix = "protobuf-964201af37f8a0009440a52a30a66317724a52c3",
+        urls = ["https://github.com/google/protobuf/archive/964201af37f8a0009440a52a30a66317724a52c3.zip"],
+    )
+
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "ca4e3b8e4da9266c3a9101c8f4704fe2e20eb5625b2a6a7d2d7d45e3dd4efffd",
+        strip_prefix = "bazel-skylib-0.5.0",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.5.0.zip"],
+    )


### PR DESCRIPTION
This allows other Bazel projects to more easily depend on Kythe without
needing to copy our entire WORKSPACE file.

Only repositories needed to build targets exposed by #3105 have been
migrated.