### PR TITLE
Remove no-op std::move

### DIFF
--- a/kythe/cxx/common/indexing/frontend.cc
+++ b/kythe/cxx/common/indexing/frontend.cc
@@ -160,7 +160,7 @@ void DecodeKZipFile(const std::string& path,
       file_data.mutable_info()->set_digest(file.info().digest());
       virtual_files->push_back(std::move(file_data));
     }
-    *unit = std::move(compilation->unit());
+    *unit = compilation->unit();
     compilation_read = true;
     return true;
   });


### PR DESCRIPTION
Fix the following lint warning: std::move of the const expression has no effect; remove std::move()