### PR TITLE
Java indexer: do not include Symbol modifiers in hashes

### DIFF
--- a/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
+++ b/kythe/java/com/google/devtools/kythe/analyzers/java/JavaEntrySets.java
@@ -48,7 +48,6 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.tools.JavaFileObject;
 
@@ -317,14 +316,7 @@ public class JavaEntrySets extends KytheEntrySets {
 
     hashes.add(sym.getQualifiedName().toString().hashCode());
     hashes.add(sym.getKind().ordinal());
-    for (Modifier mod : sym.getModifiers()) {
-      if (Modifier.FINAL == mod && sym.getKind() == ElementKind.ENUM) {
-        // Ignored due to Bazel's headers always making enums final.  See:
-        // https://github.com/google/turbine/blob/0536e276/java/com/google/turbine/binder/CompUnitPreprocessor.java#L168
-        continue;
-      }
-      hashes.add(mod.ordinal());
-    }
+    // XXX: ignore Symbol modifiers since they can be inconsistent between definitions/references.
 
     int h = hashes.hashCode();
     symbolHashes.put(sym, h);


### PR DESCRIPTION
Symbol modifiers can be inconsistent between definition/referencing compilations.  The existing exception was found due to the way Turbine handles the 'final' modifier on enums, but it can also be case that other modifiers (like 'strictfp') are inconsistent.  This change makes the symbols hashing less precise but shouldn't affect any known use-case for the indexer.