### PR TITLE
Add check for asciidoctor gem

### DIFF
--- a/kythe/web/site/Gemfile.lock
+++ b/kythe/web/site/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    asciidoctor (1.5.6.1)
+    asciidoctor (1.5.7.1)
     colorator (1.1.0)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
@@ -15,7 +15,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
-    jekyll (3.7.4)
+    jekyll (3.8.4)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)

--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -24,7 +24,7 @@
 # attributes.
 if gem list -i asciidoctor &>/dev/null; then
   echo "You don't have the asciidoctor gem installed."
-  echo "Please run 'gem install asciidoctor' before executing this script."
+  echo "Please run 'gem install --user asciidoctor' before executing this script."
   exit 1
 fi
 

--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -24,7 +24,7 @@
 # attributes.
 if [[ "$(gem list -i asciidoctor)" != "true" ]]; then
   echo "You don't have the asciidoctor gem installed."
-  echo "Please run 'sudo gem install asciidoctor' before executing this script."
+  echo "Please run 'gem install asciidoctor' before executing this script."
   exit 1
 fi
 

--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -19,6 +19,15 @@
 #
 # Usage: ./sync_docs.sh
 
+# Make sure the user has installed the asciidoc gem, otherwise the website will
+# generate successfully but it will be missing tocs, titles, and other
+# attributes.
+if [[ "$(gem list -i asciidoctor)" != "true" ]]; then
+  echo "You don't have the asciidoctor gem installed."
+  echo "Please run 'sudo gem install asciidoctor' before executing this script."
+  exit 1
+fi
+
 export SHELL=/bin/bash
 
 DIR="$(readlink -e "$(dirname "$0")")"

--- a/kythe/web/site/sync_docs.sh
+++ b/kythe/web/site/sync_docs.sh
@@ -22,7 +22,7 @@
 # Make sure the user has installed the asciidoc gem, otherwise the website will
 # generate successfully but it will be missing tocs, titles, and other
 # attributes.
-if [[ "$(gem list -i asciidoctor)" != "true" ]]; then
+if gem list -i asciidoctor &>/dev/null; then
   echo "You don't have the asciidoctor gem installed."
   echo "Please run 'gem install asciidoctor' before executing this script."
   exit 1


### PR DESCRIPTION
If you don't have the asciidoctor gem installed, you can generate a website,
but it will be missing toc/title/etc. because the commands from the script that
use the asciidoctor gem to find those values will silently fail.

Also bump the jekyll and asciidoctor versions to their latest in the gemfile