### PR TITLE
chore(platform): deprecate Go/Java indexpack libraries

### DIFF
--- a/kythe/go/platform/indexpack/BUILD
+++ b/kythe/go/platform/indexpack/BUILD
@@ -5,6 +5,7 @@ package(default_visibility = ["//kythe:default_visibility"])
 go_library(
     name = "indexpack",
     srcs = ["indexpack.go"],
+    deprecation = "Please use //kythe/go/platform/kzip",
     deps = [
         "//kythe/go/platform/analysis",
         "//kythe/go/platform/vfs",

--- a/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
+++ b/kythe/java/com/google/devtools/kythe/platform/indexpack/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//kythe:default_visibility"])
 java_library(
     name = "indexpack",
     srcs = ["Archive.java"],
+    deprecation = "Please use //kythe/java/com/google/devtools/kythe/platform/kzip",
     deps = [
         "//kythe/java/com/google/devtools/kythe/extractors/shared",
         "//kythe/java/com/google/devtools/kythe/util:json",


### PR DESCRIPTION
Match the current C++ deprecation warnings.