### PR TITLE
Another rename of for javac9-tools.jar

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/Dockerfile
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/Dockerfile
@@ -22,4 +22,4 @@ FROM debian:jessie
 ADD kythe/go/extractors/config/runextractor/runextractor /opt/kythe/extractors/runextractor
 ADD kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh /opt/kythe/extractors/javac-wrapper.sh
 ADD kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac_extractor_deploy.jar /opt/kythe/extractors/javac_extractor.jar
-ADD third_party/javac/javac-9-dev-r4023-1.jar /opt/kythe/extractors/javac8_extractor.jar
+ADD third_party/javac/javac-9-dev-r4023-1.jar /opt/kythe/extractors/javac9_tools.jar


### PR DESCRIPTION
I forgot one place when you suggested this rename last week.