### PR TITLE
Add a cloudbuild.yaml for maven extraction on Cloud Build

### DIFF
--- a/kythe/go/extractors/config/preprocessor/README.md
+++ b/kythe/go/extractors/config/preprocessor/README.md
@@ -11,7 +11,24 @@ is in and perform necessary steps.
 
 ## Invoking via docker / Cloud Build
 
-TODO(#3158): Actually fill this out with a Dockerfile and example commands.
+Insert the following step into your Cloud Build to preprocess a `pom.xml` or
+`build.gradle` file for use with Kythe extraction:
+
+```
+- name: 'gcr.io/kythe-public/build-preprocessor'
+  args: ['/workspace/path/to/pom.xml']
+```
+
+If your repo is not copied to `/workspace/` but instead lives in another volume,
+you will have to specify the volume in your build step:
+
+```
+- name: 'gcr.io/kythe-public/build-preprocessor'
+  args: ['/other/volume/pom.xml']
+  volumes:
+    - name: 'volname'
+      path: '/other/volume/'
+```
 
 ## Specific Builders
 

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -29,3 +29,34 @@ If that fails, you have to go back up to the [Cloud Build](#cloud-build) section
 and follow the installation steps.  Of note, you will have to install `gcloud`,
 authorize it, associate it with a valid project id, create a test gs bucket.
 
+## Maven Proof of Concept
+
+To extract a maven repository using Kythe on Cloud Build, use
+`mvnpoc/cloudbuild.yaml`.  This assumes that you will specify a maven repository
+in `_REPO_NAME`, and that the repository has a top-level `pom.xml` file (right
+now it is a hard-coded location, but in the future it will be configurable).
+This also assumes you specify `_BUCKET_NAME` as per the Hello World Test above.
+
+```
+gcloudbuilds submit --config cloudbuild.yaml \
+--substitutions=\
+_BUCKET_NAME="$BUCKET_NAME",\
+_REPO_NAME=https://github.com/project-name/repo-name
+```
+
+This Cloud Build uses two artifacts in gcr.io/kythe-public:
+
+### Extractor Artifacts
+
+gcr.io/kythe-public/kythe-javac-extractor-artifacts created from
+`kythe/java/com/google/devtools/kythe/extractors/java/artifacts` contains:
+
+* `javac-wrapper.sh` script which calls Kythe extraction and then an actual java
+  compiler
+* `javac_extractor.jar` which is the Kythe java extractor
+* `javac9_tools.jar` which contains javac langtools for JDK 9, but targets JRE 8
+
+gcr.io/kythe-public/build-preprocessor is just
+[kythe/go/extractors/config/preprocessor](https://github.com/google/kythe/blob/master/kythe/go/extractors/config/preprocessor/preprocessor.go),
+which we use to preprocess the `pom.xml` build configuration to be able to
+specify all of the above custom javac extraction logic.

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -38,7 +38,7 @@ now it is a hard-coded location, but in the future it will be configurable).
 This also assumes you specify `_BUCKET_NAME` as per the Hello World Test above.
 
 ```
-gcloudbuilds submit --config cloudbuild.yaml \
+gcloud builds submit --config cloudbuild.yaml \
 --substitutions=\
 _BUCKET_NAME="$BUCKET_NAME",\
 _REPO_NAME=https://github.com/project-name/repo-name

--- a/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
+++ b/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
@@ -1,0 +1,22 @@
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['clone', '${_REPO_NAME}', '/workspace/code']
+- name: 'ubuntu'
+  args: ['mkdir', '/workspace/out']
+- name: 'gcr.io/kythe-public/kythe-javac-extractor-artifacts'
+  volumes:
+    - name: 'kythe_extractors'
+      path: '/opt/kythe/extractors/'
+- name: 'gcr.io/kythe-public/build-preprocessor'
+  args: ['/workspace/code/pom.xml']
+- name: 'gcr.io/cloud-builders/mvn'
+  args: ['clean', 'compile', '-X', '-f', '/workspace/code/pom.xml', '-Dmaven.compiler.forceJavacCompilerUse=true', '-Dmaven.compiler.fork=true', '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh']
+  env: ['KYTHE_CORPUS=mvnpoctest','KYTHE_OUTPUT_DIRECTORY=/workspace/out', 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip', 'KYTHE_ROOT_DIRECTORY=/workspace/code', 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar', 'REAL_JAVAC=/usr/bin/javac', 'TMPDIR=/workspace/out', 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar']
+  volumes:
+    - name: 'kythe_extractors'
+      path: '/opt/kythe/extractors/'
+artifacts:
+  objects:
+    location: 'gs://${_BUCKET_NAME}/'
+    paths: ['/workspace/out/javac-extractor.err', '/workspace/out/test.kzip']
+

--- a/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
+++ b/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
@@ -20,7 +20,8 @@ steps:
     - '-Dmaven.compiler.fork=true'
     - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
   env:
-    - 'KYTHE_CORPUS=mvnpoctest','KYTHE_OUTPUT_DIRECTORY=/workspace/out'
+    - 'KYTHE_CORPUS=mvnpoctest'
+    -  'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
     - 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip'
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'

--- a/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
+++ b/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
@@ -10,13 +10,30 @@ steps:
 - name: 'gcr.io/kythe-public/build-preprocessor'
   args: ['/workspace/code/pom.xml']
 - name: 'gcr.io/cloud-builders/mvn'
-  args: ['clean', 'compile', '-X', '-f', '/workspace/code/pom.xml', '-Dmaven.compiler.forceJavacCompilerUse=true', '-Dmaven.compiler.fork=true', '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh']
-  env: ['KYTHE_CORPUS=mvnpoctest','KYTHE_OUTPUT_DIRECTORY=/workspace/out', 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip', 'KYTHE_ROOT_DIRECTORY=/workspace/code', 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar', 'REAL_JAVAC=/usr/bin/javac', 'TMPDIR=/workspace/out', 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar']
+  args:
+    - 'clean'
+    - 'compile'
+    - '-X'
+    - '-f'
+    - '/workspace/code/pom.xml'
+    - '-Dmaven.compiler.forceJavacCompilerUse=true'
+    - '-Dmaven.compiler.fork=true'
+    - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
+  env:
+    - 'KYTHE_CORPUS=mvnpoctest','KYTHE_OUTPUT_DIRECTORY=/workspace/out'
+    - 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip'
+    - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
+    - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'
+    - 'REAL_JAVAC=/usr/bin/javac'
+    - 'TMPDIR=/workspace/out'
+    - 'KYTHE_JAVA_RUNTIME_OPTIONS=-Xbootclasspath/p:/opt/kythe/extractors/javac9_tools.jar'
   volumes:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors/'
 artifacts:
   objects:
     location: 'gs://${_BUCKET_NAME}/'
-    paths: ['/workspace/out/javac-extractor.err', '/workspace/out/test.kzip']
+    paths:
+      - '/workspace/out/javac-extractor.err'
+      - '/workspace/out/test.kzip'
 

--- a/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
+++ b/kythe/go/extractors/gcp/mvnpoc/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
     - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
   env:
     - 'KYTHE_CORPUS=mvnpoctest'
-    -  'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
+    - 'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
     - 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip'
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'
     - 'JAVAC_EXTRACTOR_JAR=/opt/kythe/extractors/javac_extractor.jar'


### PR DESCRIPTION
Also add a bunch of docs on how to run it on a given repo.

This is progress for #3150, but still much is missing.  Notably, this only
works for a minority of maven repos, doesn't have any configuration for
subdirectory pom.xml files, doesn't support anything but java8, etc.

Also add instructions for the `preprocessors.go` binary that is now wrapped into a docker image as specified in #3158.