### PR TITLE
fix: Adding error message to git hook when commitlint not installed.

### DIFF
--- a/tools/git/commit-msg.sh
+++ b/tools/git/commit-msg.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # Check commit message: https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-if ! which commitlint; then
+if ! which commitlint &>/dev/null; then
   echo "FAILURE: commitlint not installed"
   exit 1
 fi
-command -v commitlint &>/dev/null && commitlint --edit "$1"
+commitlint --edit "$1"

--- a/tools/git/commit-msg.sh
+++ b/tools/git/commit-msg.sh
@@ -16,7 +16,7 @@
 
 # Check commit message: https://www.conventionalcommits.org/en/v1.0.0-beta.2/
 if ! which commitlint &>/dev/null; then
-  echo "FAILURE: commitlint not installed"
+  echo "FAILURE: commitlint not installed" >&2
   exit 1
 fi
 commitlint --edit "$1"

--- a/tools/git/commit-msg.sh
+++ b/tools/git/commit-msg.sh
@@ -15,4 +15,8 @@
 # limitations under the License.
 
 # Check commit message: https://www.conventionalcommits.org/en/v1.0.0-beta.2/
+if ! which commitlint; then
+  echo "FAILURE: commitlint not installed"
+  exit 1
+fi
 command -v commitlint &>/dev/null && commitlint --edit "$1"


### PR DESCRIPTION
Unclear if we'd want this somewhere else.