### PR TITLE
feat: add a gradle extraction example for cloud build

### DIFF
--- a/kythe/go/extractors/config/preprocessor/preprocessor.go
+++ b/kythe/go/extractors/config/preprocessor/preprocessor.go
@@ -69,7 +69,7 @@ func javacWrapper() string {
 	if *javac != "" {
 		return *javac
 	}
-	return constants.DefaultJavacLocation
+	return constants.DefaultJavacWrapperLocation
 }
 
 func main() {

--- a/kythe/go/extractors/gcp/README.md
+++ b/kythe/go/extractors/gcp/README.md
@@ -40,7 +40,7 @@ This also assumes you specify `_BUCKET_NAME` as per the Hello World Test above.
 ```
 gcloud builds submit --config examples/mvn.yaml \
 --substitutions=\
-_BUCKET_NAME="$BUCKET_NAME",\
+_BUCKET_NAME=$BUCKET_NAME,\
 _REPO_NAME=https://github.com/project-name/repo-name\
 --no-source
 ```
@@ -61,6 +61,18 @@ gcr.io/kythe-public/build-preprocessor is just
 [kythe/go/extractors/config/preprocessor](https://github.com/google/kythe/blob/master/kythe/go/extractors/config/preprocessor/preprocessor.go),
 which we use to preprocess the `pom.xml` build configuration to be able to
 specify all of the above custom javac extraction logic.
+
+## Gradle Proof of Concept
+
+Gradle is extracted similarly:
+
+```
+gcloud builds submit --config examples/gradle.yaml \
+--substitutions=\
+_BUCKET_NAME=$BUCKET_NAME,\
+_REPO_NAME=https://github.com/project-name/repo-name\
+--no-source
+```
 
 ## Troubleshooting
 

--- a/kythe/go/extractors/gcp/examples/gradle.yaml
+++ b/kythe/go/extractors/gcp/examples/gradle.yaml
@@ -8,19 +8,18 @@ steps:
     - name: 'kythe_extractors'
       path: '/opt/kythe/extractors/'
 - name: 'gcr.io/kythe-public/build-preprocessor'
-  args: ['/workspace/code/pom.xml']
-- name: 'gcr.io/cloud-builders/mvn'
+  args: ['/workspace/code/build.gradle']
+- name: 'gcr.io/cloud-builders/gradle'
   args:
     - 'clean'
-    - 'compile'
-    - '-X'
-    - '-f'
-    - '/workspace/code/pom.xml'
-    - '-Dmaven.compiler.forceJavacCompilerUse=true'
-    - '-Dmaven.compiler.fork=true'
-    - '-Dmaven.compiler.executable=/opt/kythe/extractors/javac-wrapper.sh'
+    - 'build'
+      - '-s'
+      - '-S'
+      - '-d'
+    - '-b'
+    - '/workspace/code/build.gradle'
   env:
-    - 'KYTHE_CORPUS=mvnpoctest'
+    - 'KYTHE_CORPUS=gradlepoctest'
     - 'KYTHE_OUTPUT_DIRECTORY=/workspace/out'
     - 'KYTHE_OUTPUT_FILE=/workspace/out/test.kzip'
     - 'KYTHE_ROOT_DIRECTORY=/workspace/code'


### PR DESCRIPTION
docs: documentation for above

fix: fix bug in preprocessor where it linked to javac, not wrapper