### PR TITLE
fix: remove runextractor from javac-extractor-artifacts

### DIFF
--- a/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/BUILD
@@ -9,7 +9,6 @@ docker_build(
     name = "artifacts",
     src = "Dockerfile",
     data = [
-        "//kythe/go/extractors/config/runextractor",
         "//kythe/java/com/google/devtools/kythe/extractors/java/standalone:javac-wrapper.sh",
         "//kythe/java/com/google/devtools/kythe/extractors/java/standalone:javac_extractor_deploy.jar",
         "//third_party/javac:javac_jar",

--- a/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/Dockerfile
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/artifacts/Dockerfile
@@ -16,10 +16,9 @@
 # Usage:
 #   This container houses java extraction artifacts which can be drawn upon in an a la
 #   carte fashion for building customized extraction images.
-# 
+#
 FROM debian:jessie
 
-ADD kythe/go/extractors/config/runextractor/runextractor /opt/kythe/extractors/runextractor
 ADD kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac-wrapper.sh /opt/kythe/extractors/javac-wrapper.sh
 ADD kythe/java/com/google/devtools/kythe/extractors/java/standalone/javac_extractor_deploy.jar /opt/kythe/extractors/javac_extractor.jar
 ADD third_party/javac/javac-9-dev-r4023-1.jar /opt/kythe/extractors/javac9_tools.jar


### PR DESCRIPTION
Since gcp/cloud build is the way forward, we no longer need this binary
to put together steps for extraction.  Instead, that now lives inside
of a yaml file.  (We'll need a separate library and potentially binary
to do similar creation of a yaml file though).