### PR TITLE
build: move vnames configuration to external target

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,31 +30,6 @@ http_archive(
     ],
 )
 
-bind(
-    name = "libuuid",
-    actual = "//third_party:libuuid",
-)
-
-bind(
-    name = "libmemcached",
-    actual = "@org_libmemcached_libmemcached//:libmemcached",
-)
-
-bind(
-    name = "guava",  # required by @com_google_protobuf
-    actual = "//third_party/guava",
-)
-
-bind(
-    name = "gson",  # required by @com_google_protobuf
-    actual = "@com_google_code_gson_gson//jar",
-)
-
-bind(
-    name = "zlib",  # required by @com_google_protobuf
-    actual = "@net_zlib//:zlib",
-)
-
 load("//tools/build_rules/external_tools:external_tools_configure.bzl", "external_tools_configure")
 
 external_tools_configure()

--- a/external.bzl
+++ b/external.bzl
@@ -554,6 +554,43 @@ def _go_dependencies():
         url = "https://github.com/google/brotli/archive/ee2a5e1540cbd6ef883a897499d9596307f7f7f9.zip",
     )
 
+def _bindings():
+    maybe(
+        native.bind,
+        name = "vnames_config",
+        actual = "@io_kythe//kythe/data:vnames_config",
+    )
+
+    maybe(
+        native.bind,
+        name = "libuuid",
+        actual = "@io_kythe//third_party:libuuid",
+    )
+
+    maybe(
+        native.bind,
+        name = "libmemcached",
+        actual = "@org_libmemcached_libmemcached//:libmemcached",
+    )
+
+    maybe(
+        native.bind,
+        name = "guava",  # required by @com_google_protobuf
+        actual = "@io_kythe//third_party/guava",
+    )
+
+    maybe(
+        native.bind,
+        name = "gson",  # required by @com_google_protobuf
+        actual = "@com_google_code_gson_gson//jar",
+    )
+
+    maybe(
+        native.bind,
+        name = "zlib",  # required by @com_google_protobuf
+        actual = "@net_zlib//:zlib",
+    )
+
 def kythe_dependencies():
     """Defines external repositories for Kythe dependencies.
 
@@ -587,3 +624,4 @@ def kythe_dependencies():
     )
 
     _rule_dependencies()
+    _bindings()

--- a/kythe/cxx/extractor/BUILD
+++ b/kythe/cxx/extractor/BUILD
@@ -190,8 +190,8 @@ extra_action(
     cmd = "$(location :cxx_extractor_bazel) \
         $(EXTRA_ACTION_FILE) \
         $(output $(ACTION_ID).c++.kindex) \
-        $(location //kythe/data:vnames_config)",
-    data = ["//kythe/data:vnames_config"],
+        $(location //external:vnames_config)",
+    data = ["//external:vnames_config"],
     out_templates = ["$(ACTION_ID).c++.kindex"],
     tools = [":cxx_extractor_bazel"],
 )
@@ -208,11 +208,11 @@ extra_action(
     cmd = "$(location :objc_extractor_bazel) \
         $(EXTRA_ACTION_FILE) \
         $(output $(ACTION_ID).objc.kindex) \
-        $(location //kythe/data:vnames_config) \
+        $(location //external:vnames_config) \
         $(location //third_party/bazel:get_devdir) \
         $(location //third_party/bazel:get_sdkroot)",
     data = [
-        "//kythe/data:vnames_config",
+        "//external:vnames_config",
         "//third_party/bazel:get_devdir",
         "//third_party/bazel:get_sdkroot",
     ],
@@ -232,8 +232,8 @@ extra_action(
     cmd = "$(location :cxx_extractor_bazel) \
         $(EXTRA_ACTION_FILE) \
         $(output $(ACTION_ID).c++.kzip) \
-        $(location //kythe/data:vnames_config)",
-    data = ["//kythe/data:vnames_config"],
+        $(location //external:vnames_config)",
+    data = ["//external:vnames_config"],
     out_templates = ["$(ACTION_ID).c++.kzip"],
     tools = [":cxx_extractor_bazel"],
 )
@@ -250,11 +250,11 @@ extra_action(
     cmd = "$(location :objc_extractor_bazel) \
         $(EXTRA_ACTION_FILE) \
         $(output $(ACTION_ID).objc.kzip) \
-        $(location //kythe/data:vnames_config) \
+        $(location //external:vnames_config) \
         $(location //third_party/bazel:get_devdir) \
         $(location //third_party/bazel:get_sdkroot)",
     data = [
-        "//kythe/data:vnames_config",
+        "//external:vnames_config",
         "//third_party/bazel:get_devdir",
         "//third_party/bazel:get_sdkroot",
     ],

--- a/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/bazel/BUILD
@@ -9,8 +9,8 @@ action_listener(
 
 extra_action(
     name = "extra_action",
-    cmd = "$(location :java_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).java.kindex) $(location //kythe/data:vnames_config)",
-    data = ["//kythe/data:vnames_config"],
+    cmd = "$(location :java_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).java.kindex) $(location //external:vnames_config)",
+    data = ["//external:vnames_config"],
     out_templates = ["$(ACTION_ID).java.kindex"],
     tools = [":java_extractor"],
 )
@@ -24,8 +24,8 @@ action_listener(
 
 extra_action(
     name = "extra_action_kzip",
-    cmd = "$(location :java_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).java.kzip) $(location //kythe/data:vnames_config)",
-    data = ["//kythe/data:vnames_config"],
+    cmd = "$(location :java_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).java.kzip) $(location //external:vnames_config)",
+    data = ["//external:vnames_config"],
     out_templates = ["$(ACTION_ID).java.kzip"],
     tools = [":java_extractor"],
 )

--- a/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
+++ b/kythe/java/com/google/devtools/kythe/extractors/java/standalone/aspect.bzl
@@ -89,7 +89,7 @@ extract_java_aspect = aspect(
     attr_aspects = ["srcs"],
     attrs = {
         "_java_aspect_vnames_config": attr.label(
-            default = Label("@io_kythe//kythe/data:vnames_config"),
+            default = Label("//external:vnames_config"),
             allow_single_file = True,
         ),
         "_java_aspect_extractor": attr.label(

--- a/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
+++ b/kythe/java/com/google/devtools/kythe/extractors/jvm/bazel/BUILD
@@ -9,8 +9,8 @@ action_listener(
 
 extra_action(
     name = "extra_action",
-    cmd = "$(location :bazel_jvm_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).jvm.kindex) $(location //kythe/data:vnames_config)",
-    data = ["//kythe/data:vnames_config"],
+    cmd = "$(location :bazel_jvm_extractor) $(EXTRA_ACTION_FILE) $(output $(ACTION_ID).jvm.kindex) $(location //external:vnames_config)",
+    data = ["//external:vnames_config"],
     out_templates = ["$(ACTION_ID).jvm.kindex"],
     tools = [":bazel_jvm_extractor"],
 )

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -201,7 +201,7 @@ cc_extract_kzip = rule(
         ),
         "vnames_config": attr.label(
             doc = "vnames_config file to be used by the extractor.",
-            default = Label("//kythe/data:vnames_config"),
+            default = Label("//external:vnames_config"),
             allow_single_file = [".json"],
         ),
         "opts": attr.string_list(
@@ -349,7 +349,7 @@ _bazel_extract_kzip = rule(
             allow_files = True,
         ),
         "vnames_config": attr.label(
-            default = Label("//kythe/data:vnames_config"),
+            default = Label("//external:vnames_config"),
             allow_single_file = True,
         ),
         "extractor": attr.label(

--- a/tools/build_rules/verifier_test/verifier_test.bzl
+++ b/tools/build_rules/verifier_test/verifier_test.bzl
@@ -225,7 +225,7 @@ java_extract_kzip = rule(
             allow_files = True,
         ),
         "vnames_config": attr.label(
-            default = Label("//kythe/data:vnames_config"),
+            default = Label("//external:vnames_config"),
             allow_single_file = True,
         ),
         "extractor": attr.label(
@@ -275,7 +275,7 @@ jvm_extract_kzip = rule(
             cfg = "host",
         ),
         "vnames_config": attr.label(
-            default = Label("//kythe/data:vnames_config"),
+            default = Label("//external:vnames_config"),
             allow_single_file = True,
         ),
         "opts": attr.string_list(),


### PR DESCRIPTION
Allow for repositories depending on Kythe to use their own VNames configuration.