### PR TITLE
retain a reference to zip source on validation error

### DIFF
--- a/kythe/cxx/common/kzip_reader.cc
+++ b/kythe/cxx/common/kzip_reader.cc
@@ -179,6 +179,9 @@ StatusOr<IndexReader> KzipReader::FromSource(zip_source_t* source) {
       return IndexReader(
           absl::WrapUnique(new KzipReader(std::move(archive), *root)));
     } else {
+      // Ensure source is retained when `archive` is deleted.
+      // It is the callers responsitility to free it on error.
+      zip_source_keep(source);
       return root.status();
     }
   }

--- a/kythe/cxx/common/kzip_reader.h
+++ b/kythe/cxx/common/kzip_reader.h
@@ -37,6 +37,8 @@ class KzipReader : public IndexReaderInterface {
   /// `zip_source_t` is reference counted, see
   /// https://libzip.org/documentation/zip_source.html
   /// for detailed ownership semantics.
+  /// Following from that, a reference will be retained on success,
+  /// but the caller is responsible for `source` on error.
   static StatusOr<IndexReader> FromSource(zip_source_t* source);
 
   Status Scan(const ScanCallback& callback) override;


### PR DESCRIPTION
The reference counting semantics of libzip object are such that it is the caller's responsibility to free constructor objects on error.  Retain a reference to the source in `KzipReader::FromSource` when validation fails so callers can do this reliably.