### PR TITLE
feat: add Seek method to keyvalue.Iterator interface

### DIFF
--- a/kythe/go/storage/inmemory/inmemory.go
+++ b/kythe/go/storage/inmemory/inmemory.go
@@ -20,6 +20,7 @@ package inmemory
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -159,6 +160,17 @@ func (p *kvPrefixIterator) Next() (key, val []byte, err error) {
 	return []byte(k), []byte(v), nil
 }
 
+// Seek implements part of the keyvalue.Iterator interface.
+func (p *kvPrefixIterator) Seek(k []byte) error {
+	s := string(k)
+	i := sort.Search(len(p.db.keys), func(i int) bool { return strings.Compare(p.db.keys[i], s) >= 0 })
+	if i < p.idx {
+		return fmt.Errorf("given key before current iterator position: %q", k)
+	}
+	p.idx = i
+	return nil
+}
+
 // Close implements part of the keyvalue.Iterator interface.
 func (p *kvPrefixIterator) Close() error {
 	p.db.mu.RUnlock()
@@ -189,6 +201,17 @@ func (p *kvRangeIterator) Next() (key, val []byte, err error) {
 	v := p.db.db[k]
 	p.idx++
 	return []byte(k), []byte(v), nil
+}
+
+// Seek implements part of the keyvalue.Iterator interface.
+func (p *kvRangeIterator) Seek(k []byte) error {
+	s := string(k)
+	i := sort.Search(len(p.db.keys), func(i int) bool { return strings.Compare(p.db.keys[i], s) >= 0 })
+	if i < p.idx {
+		return fmt.Errorf("given key before current iterator position: %q", k)
+	}
+	p.idx = i
+	return nil
 }
 
 // Close implements part of the keyvalue.Iterator interface.

--- a/kythe/go/storage/keyvalue/keyvalue.go
+++ b/kythe/go/storage/keyvalue/keyvalue.go
@@ -124,6 +124,12 @@ type Iterator interface {
 	// entry. If there is no key-value entry to return, an io.EOF error is
 	// returned.
 	Next() (key, val []byte, err error)
+
+	// Seeks positions the Iterator to the given key.  The key must be further
+	// than the current Iterator's position.  If the key does not exist, the
+	// Iterator is positioned at the next existing key.  If no such key exists,
+	// io.EOF is returned.
+	Seek(key []byte) error
 }
 
 // Writer provides write access to a DB. Writes must be Closed when no longer

--- a/kythe/go/storage/leveldb/leveldb.go
+++ b/kythe/go/storage/leveldb/leveldb.go
@@ -260,3 +260,15 @@ func (i iterator) Next() ([]byte, []byte, error) {
 	i.it.Next()
 	return key, val, nil
 }
+
+// Seek implements part of the keyvalue.Iterator interface.
+func (i *iterator) Seek(k []byte) error {
+	i.it.Seek(k)
+	if !i.it.Valid() {
+		if err := i.it.GetError(); err != nil {
+			return err
+		}
+		return io.EOF
+	}
+	return nil
+}


### PR DESCRIPTION
This is necessary to provide an efficient paging implementation for the
columnar serving formats (#2930).