### PR TITLE
fix(cxx_extractor): use the right compiler executable

### DIFF
--- a/kythe/cxx/extractor/toolchain.bzl
+++ b/kythe/cxx/extractor/toolchain.bzl
@@ -30,7 +30,7 @@ def _cxx_extractor_toolchain_impl(ctx):
         compiler_executable = cc_toolchain.compiler_executable
     cxx_extractor = CxxExtractorToolchainInfo(
         extractor_binary = ctx.attr.extractor.files_to_run,
-        compiler_executable = ctx.attr.compiler_executable,
+        compiler_executable = compiler_executable,
         cc_toolchain = cc_toolchain,
     )
     return [


### PR DESCRIPTION
Before we were accidentally unconditionally using the attribute, rather than only using the attribute to override the C++ toolchain if it was non-empty.  This doesn't work internally.