### PR TITLE
fix(rust_indexer): remove debug log call

### DIFF
--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -747,7 +747,6 @@ impl<'a, 'b> CrateAnalyzer<'a, 'b> {
                     Some(format!("The Rust indexer was unable to locate the file VName for the reference in the file \"{}\"", span.file_name.to_str().unwrap()).as_ref()),
                     None,
                 )?;
-                eprintln!("Failed to get file VName for reference: The Rust indexer was unable to locate the file VName for the reference in the file \"{}\"", span.file_name.to_str().unwrap());
                 continue;
             }
             reference_vname.set_path(file_vname.unwrap().get_path().to_string());


### PR DESCRIPTION
This PR removes a debugging line that was mistakenly committed in a prior PR