### PR TITLE
fix(rust_indexer): fix compiler warning before next compiler release

### DIFF
--- a/kythe/rust/indexer/src/indexer/analyzers.rs
+++ b/kythe/rust/indexer/src/indexer/analyzers.rs
@@ -144,7 +144,7 @@ impl<'a> UnitAnalyzer<'a> {
                 file_contents = String::from_utf8(file_bytes).map_err(|_| {
                     KytheError::IndexerError(format!(
                         "Failed to read file {} as UTF8 string",
-                        source_file.to_string()
+                        source_file
                     ))
                 })?;
             } else {


### PR DESCRIPTION
Fixes syntax that would cause a compiler warning in a future Rust compiler release