### PR TITLE
chore: remove uses of incompatible_use_toolchain_transition

### DIFF
--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -263,7 +263,6 @@ _cc_kythe_proto_library_aspect = aspect(
         ),
     },
     fragments = ["cpp"],
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     implementation = _cc_kythe_proto_library_aspect_impl,
 )

--- a/tools/build_rules/verifier_test/rust_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/rust_indexer_test.bzl
@@ -122,7 +122,6 @@ rust_extract = rule(
         "@rules_rust//rust:toolchain",
         "@bazel_tools//tools/cpp:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
 )
 
 def _rust_entries_impl(ctx):


### PR DESCRIPTION
Remove uses of `incompatible_use_toolchain_transition` now that it is enabled by default.