### PR TITLE
Revert "Remove uses of `incompatible_use_toolchain_transition` now th…

### DIFF
--- a/kythe/cxx/extractor/toolchain.bzl
+++ b/kythe/cxx/extractor/toolchain.bzl
@@ -59,6 +59,7 @@ cxx_extractor_toolchain = rule(
         ),
     },
     fragments = ["cpp"],
+    incompatible_use_toolchain_transition = True,
     provides = [
         CxxExtractorToolchainInfo,
         platform_common.ToolchainInfo,

--- a/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
+++ b/kythe/cxx/tools/fyi/testdata/compile_commands.bzl
@@ -34,6 +34,7 @@ compile_commands = rule(
         ),
     },
     doc = "Generates a compile_commannds.json.in template file.",
+    incompatible_use_toolchain_transition = True,
     outputs = {
         "compile_commands": "compile_commands.json.in",
     },


### PR DESCRIPTION
…at it is enabled by (#5118)"

This is still needed for bazel 4.x compatibility, and it a no-op in
Bazel 5.x, so it should be kept.

The API will be removed in Bazel 6.0.

Part of bazelbuild/bazel#14127.

This reverts commit 38d5a721b16c300d9e523671dc61c8e8d0b0eaa9.