### PR TITLE
fix(cxx_indexer): find vnames for pch/pcm files

### DIFF
--- a/kythe/cxx/indexer/cxx/GraphObserver.h
+++ b/kythe/cxx/indexer/cxx/GraphObserver.h
@@ -351,15 +351,14 @@ class GraphObserver {
 
   /// \brief Returns a claim token for namespaces declared at `Loc`.
   /// \param Loc The declaration site of the namespace.
-  virtual const ClaimToken* getNamespaceClaimToken(
-      clang::SourceLocation Loc) const {
+  virtual const ClaimToken* getNamespaceClaimToken(clang::SourceLocation Loc) {
     return getDefaultClaimToken();
   }
 
   /// \brief Returns a claim token for anonymous namespaces declared at `Loc`.
   /// \param Loc The declaration site of the anonymous namespace.
   virtual const ClaimToken* getAnonymousNamespaceClaimToken(
-      clang::SourceLocation Loc) const {
+      clang::SourceLocation Loc) {
     return getDefaultClaimToken();
   }
 
@@ -1076,13 +1075,13 @@ class GraphObserver {
   /// map from the FileId inside a SourceLocation to a (file, transcript)
   /// pair.
   virtual const ClaimToken* getClaimTokenForLocation(
-      const clang::SourceLocation L) const {
+      const clang::SourceLocation L) {
     return getDefaultClaimToken();
   }
 
   /// \brief Returns a `ClaimToken` covering a given source range.
   virtual const ClaimToken* getClaimTokenForRange(
-      const clang::SourceRange& SR) const {
+      const clang::SourceRange& SR) {
     return getDefaultClaimToken();
   }
 

--- a/kythe/cxx/indexer/cxx/KytheGraphObserver.h
+++ b/kythe/cxx/indexer/cxx/KytheGraphObserver.h
@@ -428,16 +428,16 @@ class KytheGraphObserver : public GraphObserver {
   }
 
   const KytheClaimToken* getClaimTokenForLocation(
-      const clang::SourceLocation source_location) const override;
+      const clang::SourceLocation source_location) override;
 
   const KytheClaimToken* getClaimTokenForRange(
-      const clang::SourceRange& source_range) const override;
+      const clang::SourceRange& source_range) override;
 
   const KytheClaimToken* getNamespaceClaimToken(
-      clang::SourceLocation loc) const override;
+      clang::SourceLocation loc) override;
 
   const KytheClaimToken* getAnonymousNamespaceClaimToken(
-      clang::SourceLocation loc) const override;
+      clang::SourceLocation loc) override;
 
   /// \brief Appends a representation of `Range` to `Ostream`.
   void AppendRangeToStream(llvm::raw_ostream& ostream,
@@ -470,7 +470,7 @@ class KytheGraphObserver : public GraphObserver {
     KytheClaimToken anonymous;  ///< Token to use for anonymous namespaces.
   };
 
-  const NamespaceTokens& getNamespaceTokens(clang::SourceLocation loc) const;
+  const NamespaceTokens& getNamespaceTokens(clang::SourceLocation loc);
 
   void AddMarkedSource(const VNameRef& vname,
                        const absl::optional<MarkedSource>& signature) {


### PR DESCRIPTION
Files loaded from pch/pcms don't trigger the same preprocessor callbacks as files encountered through normal includes. This causes us to assign them the default claim token/default file vname, which in turn breaks references from dependent modules. This PR ascribes vnames to pch/pcm-sourced files in the standard way.

It may be possible to preload claim tokens for pch/pcm files. This is left to a future PR.

In service of #5543