### PR TITLE
fix(typescript_indexer): limit ref/call spans to identifiers

### DIFF
--- a/kythe/typescript/plugin_api.ts
+++ b/kythe/typescript/plugin_api.ts
@@ -87,6 +87,12 @@ export interface IndexingOptions {
    * to emit `defines/implicit` edges instead of `defines/binding`.
    */
   emitZeroWidthSpansForModuleNodes?: boolean;
+
+  /**
+   * When enabled, ref/call source anchors span identifiers instead of full
+   * call expressions when possible.
+   */
+  emitRefCallOverIdentifier?: boolean;
 }
 
 

--- a/kythe/typescript/test.ts
+++ b/kythe/typescript/test.ts
@@ -93,7 +93,7 @@ function isTsFile(filename: string): boolean {
  */
 function verify(
     host: ts.CompilerHost, options: ts.CompilerOptions, testCase: TestCase,
-    plugins?: Plugin[]): Promise<void> {
+    plugins?: Plugin[], emitRefCallOverIdentifier?: boolean): Promise<void> {
   const rootVName: kythe.VName = {
     corpus: 'testcorpus',
     root: '',
@@ -129,6 +129,7 @@ function verify(
         verifier.stdin.write(JSON.stringify(obj) + '\n');
       },
       plugins,
+      emitRefCallOverIdentifier,
     });
   } finally {
     // Ensure we close stdin on the verifier even on crashes, or otherwise
@@ -231,10 +232,11 @@ async function testIndexer(filters: string[], plugins?: Plugin[]) {
       // plugin.ts is tested by testPlugin() test.
       continue;
     }
+    const emitRefCallOverIdentifier = testCase.name.endsWith('_id.ts');
     const start = new Date().valueOf();
     process.stdout.write(`${testCase.name}: `);
     try {
-      await verify(host, config.options, testCase, plugins);
+      await verify(host, config.options, testCase, plugins, emitRefCallOverIdentifier);
     } catch (e) {
       console.log('FAIL');
       throw e;

--- a/kythe/typescript/testdata/refcall_id.ts
+++ b/kythe/typescript/testdata/refcall_id.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Test to ensure that indexer produces ref/call edges and all data needed for callgraph.
+ * See https://kythe.io/docs/schema/callgraph.html.
+ */
+
+// clang-format off
+//- FileInitFunc=vname("fileInit:synthetic", _, _, "testdata/refcall_id", "typescript").node/kind function
+//- FileInitDef defines FileInitFunc
+//- FileInitDef.node/kind anchor
+//- FileInitDef.loc/start 0
+//- FileInitDef.loc/end 0
+// clang-format on
+
+//- @Square defines/binding Square
+//- Square.node/kind function
+class Square {
+  //- @getWidth defines/binding GetWidth
+  getWidth(): number {
+    return 42;
+  }
+
+  //- @getArea defines/binding GetArea
+  getArea() {
+    //- GetWidthCall=@getWidth ref/call GetWidth
+    //- GetWidthCall childof GetArea
+    this.getWidth() ** 2;
+  }
+}
+
+//- @Square ref/call Square
+const square = new Square();
+
+//- GetAreaCallOne=@getArea ref/call GetArea
+//- GetAreaCallOne childof FileInitFunc
+square.getArea();
+
+//- @doNothing defines/binding DoNothing
+function doNothing() {
+  //- GetAreaCallTwo=@getArea ref/call GetArea
+  //- GetAreaCallTwo childof DoNothing
+  square.getArea();
+}
+
+//- DoNothingCall=@doNothing ref/call DoNothing
+//- DoNothingCall childof FileInitFunc
+doNothing();


### PR DESCRIPTION
In service of #5691