### PR TITLE
fix(cxx_indexer): always ref a decl regardless of alternate targets

### DIFF
--- a/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
+++ b/kythe/cxx/indexer/cxx/KytheIndexerMain.cc
@@ -64,6 +64,8 @@ ABSL_FLAG(bool, record_call_directness, false,
           "Record directness of function calls.");
 ABSL_FLAG(bool, emit_usr_corpus, false,
           "Use the default corpus when emitting USR nodes.");
+ABSL_FLAG(bool, experimental_set_aliases_as_writes, false,
+          "Set protobuf aliases as writes.");
 
 namespace kythe {
 
@@ -124,6 +126,8 @@ int main(int argc, char* argv[]) {
 
     kythe::MetadataSupports meta_supports;
     auto proto = std::make_unique<ProtobufMetadataSupport>();
+    proto->SetAliasesAsWrites(
+        absl::GetFlag(FLAGS_experimental_set_aliases_as_writes));
     meta_supports.Add(std::move(proto));
     meta_supports.Add(std::make_unique<KytheMetadataSupport>());
 

--- a/kythe/cxx/indexer/cxx/testdata/proto/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/proto/BUILD
@@ -11,6 +11,31 @@ cc_proto_verifier_test(
 )
 
 cc_proto_verifier_test(
+    name = "proto_semantic_ref_test",
+    size = "medium",
+    srcs = ["proto_semantic_ref.cc"],
+    proto_libs = ["//kythe/testdata/indexers/proto:testdata_proto"],
+    verifier_opts = [
+        "--ignore_dups",
+        "--convert_marked_source",
+        "--check_for_singletons=false",
+    ],
+)
+
+cc_proto_verifier_test(
+    name = "proto_semantic_ref_aw_test",
+    size = "medium",
+    srcs = ["proto_semantic_ref_aw.cc"],
+    experimental_set_aliases_as_writes = True,
+    proto_libs = ["//kythe/testdata/indexers/proto:testdata_proto"],
+    verifier_opts = [
+        "--ignore_dups",
+        "--convert_marked_source",
+        "--check_for_singletons=false",
+    ],
+)
+
+cc_proto_verifier_test(
     name = "proto_semantic_test",
     size = "medium",
     srcs = ["proto_semantic.cc"],

--- a/kythe/cxx/indexer/cxx/testdata/proto/cc_proto_verifier_test.bzl
+++ b/kythe/cxx/indexer/cxx/testdata/proto/cc_proto_verifier_test.bzl
@@ -32,6 +32,7 @@ def cc_proto_verifier_test(
             "--convert_marked_source",
         ],
         size = "small",
+        experimental_set_aliases_as_writes = False,
         minimal_claiming = True):
     """Verify cross-language references between C++ and Proto.
 
@@ -43,6 +44,7 @@ def cc_proto_verifier_test(
       cc_indexer: The cc indexer to use
       verifier_opts: List of options passed to the verifier tool
       size: Size of the test.
+      experimental_set_aliases_as_writes: Set protobuf aliases as writes.
       minimal_claiming: If true, only index the `srcs` and protobuf header files.
 
     Returns:
@@ -104,6 +106,10 @@ def cc_proto_verifier_test(
             "--claim_unknown=false",
         ]
         claim_deps = [claim_file]
+    
+    aw_opt = []
+    if experimental_set_aliases_as_writes:
+        aw_opt = ["--experimental_set_aliases_as_writes"]
 
     cc_entries = _invoke(
         cc_index,
@@ -116,7 +122,7 @@ def cc_proto_verifier_test(
             "--noindex_template_instantiations",
             "--experimental_drop_instantiation_independent_data",
             "--noemit_anchors_on_builtins",
-        ] + claim_opt,
+        ] + claim_opt + aw_opt,
         indexer = cc_indexer,
         test_indexer = cc_indexer,
     )

--- a/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic_ref.cc
+++ b/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic_ref.cc
@@ -1,0 +1,31 @@
+#include "kythe/testdata/indexers/proto/testdata.pb.h"
+
+
+void fn() {
+  using ::pkg::proto::Message;
+
+  //- @Message ref CxxMessage
+  Message msg;
+  //- @set_string_field ref/writes StringField
+  //- @"msg.set_string_field(\"value\")" ref/call CxxSetStringField
+  //- @set_string_field ref CxxSetStringField
+  //- !{ @set_string_field ref StringField }
+  msg.set_string_field("value");
+  //- @string_field ref CxxGetStringField
+  msg.string_field();
+  //- StringField generates CxxGetStringField
+
+  // mutable_nested_message has kTakeAlias semantics, which acts like
+  // kReadWrite in emitting both ref and ref/writes.
+  Message::NestedMessage nested;
+  //- @mutable_nested_message ref/writes NestedMessageField
+  //- @"msg.mutable_nested_message()" ref/call CxxMutableNestedMessage
+  //- @mutable_nested_message ref CxxMutableNestedMessage
+  //- @mutable_nested_message ref NestedMessageField
+  *msg.mutable_nested_message() = nested;
+  //- NestedMessageField generates CxxMutableNestedMessage
+
+  //- @mutable_nested_message ref NestedMessageField
+  //- !{ @mutable_nested_message ref/writes NestedMessageField }
+  *msg.mutable_nested_message();
+}

--- a/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic_ref_aw.cc
+++ b/kythe/cxx/indexer/cxx/testdata/proto/proto_semantic_ref_aw.cc
@@ -1,0 +1,29 @@
+#include "kythe/testdata/indexers/proto/testdata.pb.h"
+
+
+void fn() {
+  using ::pkg::proto::Message;
+
+  //- @Message ref CxxMessage
+  Message msg;
+  //- @set_string_field ref/writes StringField
+  //- @"msg.set_string_field(\"value\")" ref/call CxxSetStringField
+  //- @set_string_field ref CxxSetStringField
+  //- !{ @set_string_field ref StringField }
+  msg.set_string_field("value");
+  //- @string_field ref CxxGetStringField
+  msg.string_field();
+  //- StringField generates CxxGetStringField
+
+  Message::NestedMessage nested;
+  //- @mutable_nested_message ref/writes NestedMessageField
+  //- @"msg.mutable_nested_message()" ref/call CxxMutableNestedMessage
+  //- @mutable_nested_message ref CxxMutableNestedMessage
+  //- !{ @mutable_nested_message ref NestedMessageField }
+  *msg.mutable_nested_message() = nested;
+  //- NestedMessageField generates CxxMutableNestedMessage
+
+  //- @mutable_nested_message ref/writes NestedMessageField
+  //- !{ @mutable_nested_message ref NestedMessageField }
+  *msg.mutable_nested_message();
+}


### PR DESCRIPTION
At the intersection of indirection, write refs and protobuf, we have the `mutable_` methods (without loss of generality). The C++ indexer can look underneath assignments through simple indirection (`*mutable_foo() = bar`) and can also identify the field (foo) being set. Before this PR, the indexer would not emit a ref to the `mutable_foo` function if it found a "better" reference target because of the indirection. Now, it will check to see if the alternate target is different from the ordinary referent; if so, it will emit an ordinary reference to the ordinary referent.

This PR also adds tests demonstrating the difference in behavior between `mutable_` as alias versus `mutable_` as a simple write.