### PR TITLE
chore(verifier): get rid of more direct ast access from inspections

### DIFF
--- a/kythe/cxx/verifier/assertions_to_souffle.cc
+++ b/kythe/cxx/verifier/assertions_to_souffle.cc
@@ -29,8 +29,8 @@ constexpr absl::string_view kGlobalDecls = R"(
 .type vname = [
   signature:number,
   corpus:number,
-  path:number,
   root:number,
+  path:number,
   language:number
 ]
 .decl entry(source:vname, kind:number, target:vname, name:number, value:number)
@@ -54,7 +54,7 @@ bool SouffleProgram::LowerSubexpression(AstNode* node, EVarType type) {
       if (p != 0) {
         absl::StrAppend(&code_, ", ");
       }
-      if (!LowerSubexpression(tup->element(p), type)) {
+      if (!LowerSubexpression(tup->element(p), EVarType::kSymbol)) {
         return false;
       }
     }
@@ -147,7 +147,7 @@ bool SouffleProgram::LowerGoal(const SymbolTable& symbol_table, AstNode* goal) {
         absl::StrAppend(&code_, ", false");
       } else {
         absl::StrAppend(&code_, ", v", FindEVar(evar), "=[_, ", range->corpus(),
-                        ", ", range->path(), ", ", range->root(), ", _]");
+                        ", ", range->root(), ", ", range->path(), ", _]");
         absl::StrAppend(&code_, ", at(", *beginsym, ", ", *endsym, ", v",
                         FindEVar(evar), ")");
       }

--- a/kythe/cxx/verifier/souffle_interpreter.cc
+++ b/kythe/cxx/verifier/souffle_interpreter.cc
@@ -108,12 +108,11 @@ class KytheReadStream : public souffle::ReadStream {
  private:
   void CopyVName(kythe::verifier::Tuple* vname,
                  souffle::RamDomain (&target)[5]) {
-    // output: sig, corp, path, root, lang
-    // input: sig, corp, root, path, lang
+    // sig, corp, root, path, lang
     target[0] = vname->element(0)->AsIdentifier()->symbol();
     target[1] = vname->element(1)->AsIdentifier()->symbol();
-    target[2] = vname->element(3)->AsIdentifier()->symbol();
-    target[3] = vname->element(2)->AsIdentifier()->symbol();
+    target[2] = vname->element(2)->AsIdentifier()->symbol();
+    target[3] = vname->element(3)->AsIdentifier()->symbol();
     target[4] = vname->element(4)->AsIdentifier()->symbol();
   }
   const AnchorMap& anchors_;
@@ -185,8 +184,8 @@ class KytheWriteStream : public souffle::WriteStream {
         case EVarType::kVName: {
           const auto* v = recordTable.unpack(tuple[ox], 5);
           absl::StrAppend(o, "vname(", get_symbol_(v[0]), ", ",
-                          get_symbol_(v[1]), ", ", get_symbol_(v[3]), ", ",
-                          get_symbol_(v[2]), ", ", get_symbol_(v[4]), ")");
+                          get_symbol_(v[1]), ", ", get_symbol_(v[2]), ", ",
+                          get_symbol_(v[3]), ", ", get_symbol_(v[4]), ")");
         } break;
         case EVarType::kSymbol: {
           *o = get_symbol_(tuple[ox]);
@@ -245,8 +244,7 @@ SouffleResult RunSouffle(
     const SymbolTable& symbol_table, const std::vector<GoalGroup>& goal_groups,
     const Database& database, const AnchorMap& anchors,
     const std::vector<Inspection>& inspections,
-    std::function<bool(const Inspection&, std::optional<std::string_view>)>
-        inspect,
+    std::function<bool(const Inspection&, std::string_view)> inspect,
     std::function<std::string(size_t)> get_symbol) {
   SouffleResult result{};
   SouffleProgram program;

--- a/kythe/cxx/verifier/souffle_interpreter.h
+++ b/kythe/cxx/verifier/souffle_interpreter.h
@@ -39,7 +39,7 @@ struct SouffleResult {
 /// \param inspect the inspection callback that will be used against the
 /// provided list of inspections; a false return value stops iterating through
 /// inspection results and fails the solution, while a true result continues.
-/// If set, `value` is a string representation of the assignment of the EVar to
+/// `value` is a string representation of the assignment of the EVar to
 /// which the inspection refers.
 /// \param get_symbol returns a string representation of the given symbol
 /// \return a `SouffleResult` describing how the run went.
@@ -47,9 +47,7 @@ SouffleResult RunSouffle(
     const SymbolTable& symbol_table, const std::vector<GoalGroup>& goal_groups,
     const Database& database, const AnchorMap& anchors,
     const std::vector<Inspection>& inspections,
-    std::function<bool(const Inspection&,
-                       std::optional<std::string_view> value)>
-        inspect,
+    std::function<bool(const Inspection&, std::string_view value)> inspect,
     std::function<std::string(size_t)> get_symbol);
 }  // namespace kythe::verifier
 

--- a/kythe/cxx/verifier/verifier.cc
+++ b/kythe/cxx/verifier/verifier.cc
@@ -968,14 +968,13 @@ void Verifier::DumpErrorGoal(size_t group, size_t index) {
 }
 
 bool Verifier::VerifyAllGoals(
-    std::function<bool(Verifier*, const Inspection&,
-                       std::optional<std::string_view>)>
+    std::function<bool(Verifier*, const Inspection&, std::string_view)>
         inspect) {
   if (use_fast_solver_) {
     auto result = RunSouffle(
         symbol_table_, parser_.groups(), facts_, anchors_,
         parser_.inspections(),
-        [&](const Inspection& i, std::optional<std::string_view> o) {
+        [&](const Inspection& i, std::string_view o) {
           return inspect(this, i, o);
         },
         [&](Symbol s) { return symbol_table_.PrettyText(s); });
@@ -988,7 +987,7 @@ bool Verifier::VerifyAllGoals(
     }
     std::function<bool(Verifier*, const Inspection&)> wi =
         [&](Verifier* v, const Inspection& i) {
-          return inspect(v, i, std::nullopt);
+          return inspect(v, i, v->InspectionString(i));
         };
     Solver solver(this, facts_, anchors_, wi);
     bool result = solver.Solve();

--- a/kythe/cxx/verifier/verifier.h
+++ b/kythe/cxx/verifier/verifier.h
@@ -96,7 +96,7 @@ class Verifier {
   /// \param inspect function to call on any inspection request
   /// \return true if all goals could be satisfied.
   bool VerifyAllGoals(std::function<bool(Verifier* context, const Inspection&,
-                                         std::optional<std::string_view>)>
+                                         std::string_view)>
                           inspect);
 
   /// \brief Attempts to satisfy all goals from all loaded rule files and facts.
@@ -104,10 +104,8 @@ class Verifier {
   /// \return true if all goals could be satisfied.
   bool VerifyAllGoals(
       std::function<bool(Verifier* context, const Inspection&)> inspect) {
-    return VerifyAllGoals(
-        [&](Verifier* v, const Inspection& i, std::optional<std::string_view>) {
-          return inspect(v, i);
-        });
+    return VerifyAllGoals([&](Verifier* v, const Inspection& i,
+                              std::string_view) { return inspect(v, i); });
   }
 
   /// \brief Attempts to satisfy all goals from all loaded rule files and facts.


### PR DESCRIPTION
This PR also reorders the fields of the vname tuple to reflect the external documentation (the old solver reordered them as an optimization; we don't need to do this anymore). There's a fix to type ascription as well (fields of vnames should be identifiers).