### PR TITLE
feat(cxx_indexer): Index dependent template specialization types.

### DIFF
--- a/kythe/cxx/indexer/cxx/IndexerASTHooks.h
+++ b/kythe/cxx/indexer/cxx/IndexerASTHooks.h
@@ -360,6 +360,12 @@ class IndexerASTVisitor : public RecursiveTypeVisitor<IndexerASTVisitor> {
   NodeSet BuildNodeSetForSubstTemplateTypeParm(
       const clang::SubstTemplateTypeParmType& T);
   NodeSet BuildNodeSetForDependentName(const clang::DependentNameType& T);
+  // Builds node IDs for the provided list of template arguments. Returns an
+  // empty vector if any node ID could not be generated.
+  std::vector<GraphObserver::NodeId> BuildNodeIdsForTemplateArgs(
+      clang::ArrayRef<clang::TemplateArgument> args);
+  NodeSet BuildNodeSetForDependentTemplateSpecialization(
+      const clang::DependentTemplateSpecializationType& T);
   NodeSet BuildNodeSetForTemplateSpecialization(
       const clang::TemplateSpecializationType& T);
   NodeSet BuildNodeSetForPackExpansion(const clang::PackExpansionType& T);

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2225,6 +2225,13 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template_dependent_template_specialization_type",
+    srcs = ["template/template_dependent_template_specialization_type.cc"],
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_depexpr_field_ref",
     srcs = ["template/template_depexpr_field_ref.cc"],
     ignore_dups = True,

--- a/kythe/cxx/indexer/cxx/testdata/template/template_dependent_template_specialization_type.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_dependent_template_specialization_type.cc
@@ -1,0 +1,9 @@
+// We index dependent template specialization types.
+//- @U defines/binding TvarU
+template <typename T, typename U>
+//- @A defines/binding AliasA
+using A = T::template S<U>;
+//- AliasA aliases TAppTSU
+//- TAppTSU.node/kind tapp
+//- TAppTSU param.0 _DependentTS  // Dependent struct not yet indexed.
+//- TAppTSU param.1 TvarU


### PR DESCRIPTION
This should help us on the path to better handling e.g. type_traits and associates, which in turn should help us find dependent references.

At the moment the indexer does not emit a node for template T::S; this is left for future work.