### PR TITLE
Avoid creating dangling edges when aliasing is on.

### DIFF
--- a/kythe/cxx/indexer/cxx/clang_utils.cc
+++ b/kythe/cxx/indexer/cxx/clang_utils.cc
@@ -107,6 +107,24 @@ const clang::Decl* DereferenceMemberTemplates(const clang::Decl* decl) {
   return DereferenceMemberTemplatesDeclVisitor().Visit(decl);
 }
 
+bool IsExplicitOrInstantiatedFromPartialSpecialization(
+    const clang::CXXRecordDecl* decl) {
+  if (const auto* template_decl =
+          clang::dyn_cast_or_null<clang::ClassTemplateSpecializationDecl>(
+              decl)) {
+    if (template_decl->isExplicitSpecialization()) {
+      return true;
+    }
+    auto instantiated_from = template_decl->getInstantiatedFrom();
+    if (!instantiated_from.isNull() &&
+        instantiated_from
+            .is<clang::ClassTemplatePartialSpecializationDecl*>()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const clang::Decl* FindSpecializedTemplate(const clang::Decl* decl) {
   if (const auto* FD = llvm::dyn_cast<const clang::FunctionDecl>(decl)) {
     if (auto* ftsi = FD->getTemplateSpecializationInfo()) {

--- a/kythe/cxx/indexer/cxx/clang_utils.h
+++ b/kythe/cxx/indexer/cxx/clang_utils.h
@@ -18,6 +18,7 @@
 #define KYTHE_CXX_INDEXER_CXX_CLANG_UTILS_H_
 
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceManager.h"
@@ -26,6 +27,11 @@
 namespace kythe {
 /// \return true if `DN` is an Objective-C selector.
 bool isObjCSelector(const clang::DeclarationName& DN);
+
+/// \return true if `decl` is an explicit template specialization or was
+/// instantiated from a partial specialization.
+bool IsExplicitOrInstantiatedFromPartialSpecialization(
+    const clang::CXXRecordDecl* decl);
 
 /// \brief If `decl` is an implicit template instantiation or specialization,
 /// returns the primary template or the partial specialization being

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -2131,6 +2131,15 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template_class_inst_explicit_aliasing",
+    srcs = ["template/template_class_inst_explicit_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_class_inst_implicit",
     srcs = ["template/template_class_inst_implicit.cc"],
     # Type alias alias inside a class template gets the same documentation text.
@@ -2156,6 +2165,15 @@ cc_indexer_test(
 cc_indexer_test(
     name = "template_class_ref",
     srcs = ["template/template_class_ref.cc"],
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
+    name = "template_class_ref_aliasing",
+    srcs = ["template/template_class_ref_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
     ignore_dups = True,
     tags = ["template"],
 )
@@ -2502,6 +2520,16 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template_nested_name_aliasing",
+    srcs = ["template/template_nested_name_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    ignore_code_conflicts = True,
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_multilevel_argument",
     srcs = ["template/template_multilevel_argument.cc"],
     ignore_dups = True,
@@ -2587,8 +2615,26 @@ cc_indexer_test(
 )
 
 cc_indexer_test(
+    name = "template_rec_inherit_aliasing",
+    srcs = ["template/template_rec_inherit_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
     name = "template_rec_override",
     srcs = ["template/template_rec_override.cc"],
+    ignore_dups = True,
+    tags = ["template"],
+)
+
+cc_indexer_test(
+    name = "template_rec_override_aliasing",
+    srcs = ["template/template_rec_override_aliasing.cc"],
+    check_for_singletons = True,
+    experimental_alias_template_instantiations = True,
     ignore_dups = True,
     tags = ["template"],
 )

--- a/kythe/cxx/indexer/cxx/testdata/template/template_class_inst_explicit_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_class_inst_explicit_aliasing.cc
@@ -1,0 +1,17 @@
+// Checks the behavior of explicit class template instantiations under aliasing.
+using ExternalDef = int;
+//- @C defines/binding TemplateC
+template <typename T> struct C {
+  using X = ExternalDef;
+};
+//- @C ref TemplateC
+//- @C defines/binding ExplicitC
+template struct C<int>;
+//- ExplicitC specializes TAppCInt
+//- ExplicitC instantiates TAppCInt
+//- TAppCInt param.0 TemplateC
+//- ExplicitC.node/kind record
+//- ExternalDefAlias childof ExplicitC
+//- ExternalDefAlias.node/kind talias
+//- SomeA defines/binding ExternalDefAlias
+//- SomeA.node/kind anchor

--- a/kythe/cxx/indexer/cxx/testdata/template/template_class_ref_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_class_ref_aliasing.cc
@@ -1,0 +1,36 @@
+//- @S defines/binding SPrim
+//- @S defines/binding S1
+template <typename T, typename U> struct S {};
+//- @S defines/binding S2
+//- S2.node/kind record  // avoid implicit constructors
+template <typename T> struct S<T, int> {};
+//- @S defines/binding S3
+//- S3.node/kind record
+template <typename T> struct S<T, float> {};
+//- @S defines/binding S4
+//- S4.node/kind record
+template <typename U> struct S<int, U> {};
+//- @S defines/binding S5
+//- S5.node/kind record
+template <typename U> struct S<float, U> {};
+//- @S defines/binding S6
+//- S6.node/kind record
+template <> struct S<char, char> {};
+
+//- @S ref S1
+S<void *, void *> s1;
+//- @S ref S2
+S<void *, int> s2;
+//- @S ref S3
+S<void *, float> s3;
+//- @S ref S4
+S<int, void *> s4;
+//- @S ref S5
+S<float, void *> s5;
+//- @S ref S6
+S<char, char> s6;
+
+template <typename T, typename U> void f() {
+  //- @S ref SPrim
+  S<T, U> s;
+}

--- a/kythe/cxx/indexer/cxx/testdata/template/template_nested_name_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_nested_name_aliasing.cc
@@ -1,0 +1,23 @@
+// We emit references to nodes in nested names.
+template <typename T>
+//- @S defines/binding StructS
+struct S {
+  static T x;
+  template <typename U>
+  //- @V defines/binding _StructV
+  struct V {
+    static U y;
+  };
+};
+
+//- @S ref _SInt
+//- @V ref _VFloat
+//- @int ref _Int
+//- @float ref _Float
+double z = S<int>::V<float>::y;
+
+//- // SInt instantiates AppSInt  -- These edges are not emitted with aliasing.
+//- // VFloat instantiates AppVFloat
+//- _AppSInt param.0 StructS
+//- _AppVFloat param.0 NominalV
+//- NominalV.node/kind record

--- a/kythe/cxx/indexer/cxx/testdata/template/template_rec_inherit_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_rec_inherit_aliasing.cc
@@ -1,0 +1,9 @@
+// Verifies that we emit a reference to template base classes.
+//- @C defines/binding TemplateC
+template <typename T> class C {};
+//- @C ref TemplateC
+//- @"C<int>" ref TAppCInt
+//- TAppCInt param.0 TemplateC
+//- TAppCInt param.1 Int
+//- @int ref Int
+struct S : C<int> {};

--- a/kythe/cxx/indexer/cxx/testdata/template/template_rec_override_aliasing.cc
+++ b/kythe/cxx/indexer/cxx/testdata/template/template_rec_override_aliasing.cc
@@ -1,0 +1,17 @@
+// We index overrides that come from templates.
+//- @f defines/binding CF
+//- CF.node/kind function
+//- @C defines/binding TemplateC
+//- TemplateC.node/kind record
+//- CF childof CInstInt
+//- CInstInt.node/kind record
+//- // CInstInt instantiates TAppCInt  // Not in the aliased graph.
+//- TAppCInt param.0 TemplateC
+template <typename T> class C { virtual void f() { } };
+//- @f defines/binding DF
+//- DF.node/kind function
+//- DF overrides TAppCF
+//- TAppCF param.0 CF
+//- @C ref TemplateC
+//- @"C<int>" ref TAppCInt
+class D : public C<int> { void f() override { } };

--- a/tools/build_rules/verifier_test/cc_indexer_test.bzl
+++ b/tools/build_rules/verifier_test/cc_indexer_test.bzl
@@ -56,6 +56,7 @@ _VERIFIER_FLAGS = {
     "convert_marked_source": False,
     "goal_prefix": "//-",
     "ignore_dups": False,
+    "ignore_code_conflicts": False,
 }
 
 _INDEXER_LOGGING_ENV = {
@@ -824,6 +825,7 @@ def cc_indexer_test(
       experimental_drop_instantiation_independent_data: Whether the indexer should
         drop extraneous instantiation independent data.
       experimental_usr_byte_size: How many bytes of a USR to use.
+      ignore_code_conflicts: Ignore conflicting /kythe/code facts during verification.
     """
     _indexer_test(
         name = name,


### PR DESCRIPTION
This PR also adds a flag to turn the new behavior off if necessary.