### PR TITLE
fix(proto_indexer): typo in anchor spec

### DIFF
--- a/kythe/cxx/indexer/proto/testdata/basic/map.proto
+++ b/kythe/cxx/indexer/proto/testdata/basic/map.proto
@@ -11,6 +11,6 @@ message Message {
   map<string, int32> builtin_map = 1;
 
   //- @Value ref ValueMsg
-  //- !{ "@map<string, Value>" ref _MessageMap }
+  //- !{ @"map<string, Value>" ref _MessageMap }
   map<string, Value> message_map = 2;
 }


### PR DESCRIPTION
Found this while debugging the new solver. We should probably catch this earlier and print a nice diagnostic.