### PR TITLE
fix(verifier): work around issue in groundedness check

### DIFF
--- a/kythe/cxx/verifier/assertions_to_souffle.cc
+++ b/kythe/cxx/verifier/assertions_to_souffle.cc
@@ -34,6 +34,9 @@ constexpr absl::string_view kGlobalDecls = R"(
   path:number,
   language:number
 ]
+.decl sym(id:number)
+sym(0).
+sym(n + 1) :- sym(n), n >= 1.
 .decl entry(source:vname, kind:number, target:vname, name:number, value:number)
 .input entry(IO=kythe)
 .decl anchor(begin:number, end:number, vname:vname)
@@ -115,7 +118,7 @@ bool SouffleProgram::LowerGoalGroup(const SymbolTable& symbol_table,
     }
     absl::StrAppend(&code_, ")\n");
   } else {
-    absl::StrAppend(&code_, ", 0 = count:{true");
+    absl::StrAppend(&code_, ", 0 = count:{true, sym(_)");
     for (const auto& goal : group.goals) {
       if (!LowerGoal(symbol_table, goal)) return false;
     }

--- a/kythe/cxx/verifier/verifier_unit_test.cc
+++ b/kythe/cxx/verifier/verifier_unit_test.cc
@@ -1168,6 +1168,32 @@ fact_value: "42"
   ASSERT_FALSE(v.VerifyAllGoals());
 }
 
+TEST_P(VerifierTest, DontCareInNegativeIsGroundedPass) {
+  ASSERT_TRUE(v.LoadInlineProtoFile(R"(entries {
+#- !{X typed vname(_,"","3","","")}
+source { root:"1" }
+edge_kind: "/kythe/edge/typed"
+target { root:"2" }
+fact_name: "/"
+fact_value: ""
+})"));
+  ASSERT_TRUE(v.PrepareDatabase());
+  ASSERT_TRUE(v.VerifyAllGoals());
+}
+
+TEST_P(VerifierTest, DontCareInNegativeIsGroundedFail) {
+  ASSERT_TRUE(v.LoadInlineProtoFile(R"(entries {
+#- !{X typed vname(_,"","2","","")}
+source { root:"1" }
+edge_kind: "/kythe/edge/typed"
+target { root:"2" }
+fact_name: "/"
+fact_value: ""
+})"));
+  ASSERT_TRUE(v.PrepareDatabase());
+  ASSERT_FALSE(v.VerifyAllGoals());
+}
+
 TEST(VerifierUnitTest, EVarsUnsetAfterNegatedBlock) {
   Verifier v;
   ASSERT_TRUE(v.LoadInlineProtoFile(R"(entries {


### PR DESCRIPTION
Work around what looks to be a problem in the groundedness check wrt aggregates. This manifests as a failure to lower a verifier program with a _ in a vname inside a negated goal.