### PR TITLE
feat(verifier): support error recovery with the fast solver

### DIFF
--- a/kythe/cxx/verifier/BUILD
+++ b/kythe/cxx/verifier/BUILD
@@ -64,6 +64,7 @@ cc_library(
         ":lexparse",
         "//third_party/souffle:parse_transform",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
         "@souffle",
@@ -95,6 +96,7 @@ cc_library(
     deps = [
         ":lexparse",
         ":pretty_printer",
+        "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/strings",


### PR DESCRIPTION
This PR adds error recovery to the fast solver. It behaves like recovery in the old solver (where the first goal/goal group to fail in linear order are reported). Unfortunately, we have to do this by re-running the solver while we walk back each individual goal.

Note that UseFileNodes should be called *before* any parsing function. This already happens in verifier_main, but some tests were calling it afterward. The old solver does a bunch of work in PrepareDatabase (including handling assertions in file nodes), while the fast solver handles everything during parsing. (This avoids an expensive sort.)