### PR TITLE
fix: don't use -1 for whole file offsets

### DIFF
--- a/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
+++ b/kythe/java/com/google/devtools/kythe/platform/shared/ProtobufMetadataLoader.java
@@ -150,8 +150,6 @@ public class ProtobufMetadataLoader implements MetadataLoader {
     }
     for (VName vname : fileVNames) {
       Metadata.Rule rule = new Metadata.Rule();
-      rule.begin = -1;
-      rule.end = -1;
       rule.vname = vname;
       rule.reverseEdge = true;
       rule.edgeOut = EdgeKind.GENERATES;


### PR DESCRIPTION
The schema now defines [0, 0) as an anchor that covers an entire file. The offsets set in this file are never actually used (since they go into the file-scope rule list), so keeping them around is confusing at best.