### PR TITLE
C++ indexer: Support extension/Any in TextProto

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -39,3 +39,4 @@ Alexander Bezzubov <alex@sourced.tech>
 Ayaz Hafiz <ayaz.hafiz.1@gmail.com>
 Nick Gonzalez <nickgonzalez@google.com>
 Chuthan Vijay <chuthan20@gmail.com>
+Yi Su <mrsuyi@google.com>

--- a/kythe/cxx/indexer/cxx/testdata/BUILD
+++ b/kythe/cxx/indexer/cxx/testdata/BUILD
@@ -1770,6 +1770,7 @@ cc_indexer_test(
     deps = [
         "libraries/message.proto.h",
         "libraries/parsetextproto.h",
+        "libraries/proto_extension.h",
     ],
 )
 
@@ -1781,6 +1782,7 @@ cc_indexer_test(
     deps = [
         "libraries/message.proto.h",
         "libraries/parsetextproto.h",
+        "libraries/proto_extension.h",
     ],
 )
 

--- a/kythe/cxx/indexer/cxx/testdata/libraries/message.proto.h
+++ b/kythe/cxx/indexer/cxx/testdata/libraries/message.proto.h
@@ -1,13 +1,26 @@
 // This mimicks a generated protobuf:
+//
+// package some.package;
+//
 // message Inner {
 //   optional int32 my_int = 1;
+//   extends proto2.bridge.MessageSet {
+//     Outer message_set_extension = 1234321;
+//   }
 // }
 // message Outer {
 //   optional Inner inner = 1;
 //   optional int my_int = 2;
+//   optional proto2.bridge.MessageSet = 3;
+// }
+//
+// extends Inner {
+//   float global_extension = 123;
 // }
 #ifndef KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_MESSAGE_PROTO_H_
 #define KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_MESSAGE_PROTO_H_
+
+#include "proto_extension.h"
 
 class string;
 
@@ -20,6 +33,13 @@ class Inner {
   //- @my_int defines/binding MyIntAccessor
   //- MyIntAccessor childof InnerProto
   int my_int() const;
+
+  //- @message_set_extension defines/binding MsgSetExtId
+  //- MsgSetExtId childof InnerProto
+  static ::proto2::internal::ExtensionIdentifier<
+      ::proto2::bridge::MessageSet,
+      ::proto2::internal::MessageTypeTraits<::some::package::Inner>>
+      message_set_extension;
 };
 
 //- @Outer defines/binding OuterProto
@@ -31,9 +51,17 @@ class Outer {
   //- @my_string defines/binding MyStringAccessor
   //- MyStringAccessor childof OuterProto
   const string& my_string() const;
+  //- @msg_set defines/binding MsgSetAccessor
+  //- MsgSetAccessor childof OuterProto
+  const proto2::bridge::MessageSet& msg_set() const;
 };
+
+//- @message_set_extension defines/binding GlobalExtId
+extern ::proto2::internal::ExtensionIdentifier<
+    ::some::package::Inner, ::proto2::internal::PrimitiveTypeTraits<float>>
+    global_extension;
+
 }  // namespace package
 }  // namespace some
 
 #endif  // KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_MESSAGE_PROTO_H_
-

--- a/kythe/cxx/indexer/cxx/testdata/libraries/proto_extension.h
+++ b/kythe/cxx/indexer/cxx/testdata/libraries/proto_extension.h
@@ -1,0 +1,27 @@
+#ifndef KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_PROTO_EXTENSION_H_
+#define KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_PROTO_EXTENSION_H_
+
+// The following declarations mimick the proto2 Extension API.
+namespace proto2 {
+
+namespace bridge {
+
+class MessageSet {};
+
+}  // namespace bridge
+
+namespace internal {
+
+template <typename Type>
+class PrimitiveTypeTraits {};
+template <typename Type>
+class MessageTypeTraits {};
+
+template <typename ExtendeeType, typename TypeTraitsType>
+class ExtensionIdentifier {};
+
+}  // namespace internal
+
+}  // namespace proto2
+
+#endif  // KYTHE_CXX_INDEXER_CXX_TESTDATA_LIBRARIES_PROTO_EXTENSION_H_

--- a/kythe/cxx/indexer/cxx/testdata/libraries/proto_parsetextproto.cc
+++ b/kythe/cxx/indexer/cxx/testdata/libraries/proto_parsetextproto.cc
@@ -13,7 +13,22 @@ void f() {
           "  my_int: 3\n"
           " }"
           //- @my_string ref MyStringAccessor
-          " my_string: 'blah'");
+          " my_string: 'blah'"
+          //- @msg_set ref MsgSetAccessor
+          " msg_set { "
+          //- @"some.package.Inner" ref MsgSetExtId
+          "  [some.package.Inner] {"
+          //- @my_int ref MyIntAccessor
+          "    my_int: 6\n"
+          //- @"some.package.global_extension" ref GlobalExtId
+          "    [some.package.global_extension]: 0.9\n"
+          "  }"
+          " }"
+          //- @"some.package.Inner" ref InnerProto
+          " [type.googleapis.com/some.package.Inner] {"
+          //- @my_int ref MyIntAccessor
+          "  my_int: 9\n"
+          " }");
   //- @my_string ref MyStringAccessor
   msg.my_string();
   //- @inner ref InnerAccessor
@@ -23,15 +38,14 @@ void f() {
 }
 
 void g() {
-  const some::package::Outer msg =
-      PARSE_TEXT_PROTO(
-          //- @inner ref InnerAccessor
-          " inner {"
-          //- @my_int ref MyIntAccessor
-          "  my_int: 3\n"
-          " }"
-          //- @my_string ref MyStringAccessor
-          " my_string: 'blah'");
+  const some::package::Outer msg = PARSE_TEXT_PROTO(
+      //- @inner ref InnerAccessor
+      " inner {"
+      //- @my_int ref MyIntAccessor
+      "  my_int: 3\n"
+      " }"
+      //- @my_string ref MyStringAccessor
+      " my_string: 'blah'");
   //- @my_string ref MyStringAccessor
   msg.my_string();
   //- @inner ref InnerAccessor


### PR DESCRIPTION
Build reference for proto2 extensions and google.protobuf.Any inside textproto strings in C++ code.

Notice that extension only works if the proto header that defines the extension is included into this translation unit.